### PR TITLE
docs(retro): 2026-08-18 retrospective — a merge deleted a row from the append-only ledger

### DIFF
--- a/docs/architecture/retrospectives/2026-08-18.md
+++ b/docs/architecture/retrospectives/2026-08-18.md
@@ -1,0 +1,139 @@
+## Suite retrospective: wai-skill-suite · 2026-08-18
+
+**Period:** 2026-08-16 (last report marker) → 2026-08-18 · anchor set by the ledger marker
+`<!-- report 2026-08-16 rows=26 -->`
+**Suite version:** `not stamped` (no `.claude/.wai-suite-version`; doctor flags it)
+**Trigger:** explicit request — **2 verdicts since the last marker, threshold 25**. Below
+threshold and legitimate as a request, but the period is thin: two gate rows, three run-log rows,
+zero merge commits. Read every rate below against those denominators.
+
+### The numbers (script-derived, pasted verbatim)
+
+```
+## Gate report — 2026-08-18
+
+Ledger: `docs/architecture/gate-ledger.md` · period covered: 2026-08-05 → 2026-08-16
+
+- verdicts: 28 — GO 4 · NO-GO 23 · UNKNOWN 1 · MOOT 0
+- outcome coverage: 26 of 28 tagged (93%) · 2 untagged
+- 1 unmatched tag(s): need inspection — these rows are in NO rate below
+- false positives: 0 of 22 judged NO-GOs = 0% (ok 22 · fp 0)
+- false negatives: 0 of 3 judged GO rows = 0%
+- NO-GO causes: setup 4 · checks 3 · domain 16 · other 0 (of 23 NO-GO rows)
+- calibration: 0 of 22 correct NO-GOs were marked 'better GO' by the human (0 of 22 judged = 0%)
+- top exclusion reasons: EX-GUARD 14 · EX-CONTRACT 9 · EX-PAY 7 · EX-GDPR 6 · EX-SEC 4
+```
+
+```
+retro-compliance: .
+  period: last report marker in docs/architecture/gate-ledger.md (2026-08-16)
+  run-log rows: 3 (docs/architecture/run-log.md)
+    per skill: wai-pr-review 2 · wai-retro 1
+  gate-ledger verdicts: 2 — GO 1 · NO-GO 1 · UNKNOWN 0 · MOOT 0 (docs/architecture/gate-ledger.md)
+  merged PRs: none — 0 merge commits in the period (git log --merges; squash/rebase merges leave none)
+  traced share: not derivable — 0 merged PRs with a readable number is an empty denominator, not 100% compliance
+```
+
+**Scope note, stated because the two extracts disagree on purpose.** `gate-stats --report` reads
+the whole ledger (28 rows, 2026-08-05 → 2026-08-16); `retro-compliance` anchors to the marker
+(2 rows). The all-time rates below are all-time; the period is the 2-row column.
+
+### What held
+
+- **The gate's second GO landed, and the conjunction split.** Period rows: NO-GO at
+  2026-08-16T22:00Z (`ci=IN_PROGRESS`), GO at 22:02Z on the same PR once CI reported. Two rows,
+  two states, one PR — the mechanical half changing its answer for a stated, re-derivable reason.
+- **No false negative on record: 0 of 3 judged GO rows.** Denominator stated because it is the
+  whole result — three judged GOs is not evidence of a low fn rate, it is evidence that nothing
+  has gone wrong yet across three chances.
+- **`numbers-lint` caught a derived claim going stale within minutes.** PR #28 tagged a ledger
+  row `ok` and left `open-questions.md` Q1 claiming `1 untagged`; the lint went red on the
+  mismatch (2 failing cases, one cause) and CI blocked the PR. Artifact: run
+  31973230557 → 32072204150 (red → green on a one-word fix).
+- **`open-items.sh` derived 6 of 7 checkable classes** and named the seventh's absence rather
+  than skipping it silently.
+
+### What broke
+
+- **A merge deleted a row from the append-only ledger, and the row count went *up*.**
+  PR #28 merged 21:51Z carrying its gate row (`2026-08-14T16:45Z | 28 | NO-GO`, ledger 27 rows).
+  PR #31 merged 21:59Z from a branch cut before it, and its squash carried the older ledger
+  forward: **27 → 28 rows, +2 for PR #31, −1 for PR #28.** `git show ddca5f3 --
+  docs/architecture/gate-ledger.md` shows the deletion as a literal `-` line.
+  The ledger header says *"APPEND-ONLY. Never edit or delete a past row."* — a merge did.
+  Raw counts: 1 row lost of 28; PR #28's **run-log** row survived the same race, so the two
+  append-only files now disagree about whether that run happened.
+- **The merged-but-unreachable sweep cannot see this class.** `open-items.sh` reports
+  *"all merge commits of the last 17 merged PRs are ancestors of origin/HEAD"* — true, and not
+  the question. It checks whether the **commit** arrived, not whether its **content** survived a
+  later squash. The sweep exists because of field report `2026-08-06-merged-but-not-on-main.md`;
+  this period produced its sibling, and the sweep was green throughout.
+- **This skill's own documented invocations are cwd-wrong — three of three.** `SKILL.md` says to
+  run `doctor.sh`, `gate-stats.sh` and `open-items.sh` *"from this skill's directory"*. All three
+  resolve their inputs relative to the **cwd**:
+  - `gate-stats.sh` → `exit 2`, *"no ledger at docs/architecture/gate-ledger.md"*. Per the skill's
+    own fail-closed rule that is a `not measured` — a **false blank caused by the instruction**.
+  - `doctor.sh` audited the skill folder as if it were the repo and printed
+    *"no drift that disables a feature"* over "no quality catalog", "no merge gate installed" —
+    a **false clean**, and it printed **no cadence advisory at all**, which is the documented
+    trigger. It takes `[repo-root]`; the skill never passes one.
+  - Both were only caught by running them. `contract-lint.sh` is green and says so honestly:
+    it verifies documented paths resolve *from the repo root* and never that an invocation works.
+- **`traced share: not derivable`, for the second retro running.** Two PRs merged in the window
+  by squash; `git log --merges` sees none, so the compliance metric's denominator is empty. This
+  is issue #24, still open, and it is now the only section of this report that measures nothing.
+
+### Calibration
+
+- **0 of 22 correct NO-GOs were marked 'better GO' (0%, 22 judged).** No human has yet judged a
+  correct NO-GO to be unwanted — the gate is not measurably over-blocking.
+- Read against the cause split: **domain 16 of 23 NO-GOs**, top tags EX-GUARD 14 · EX-CONTRACT 9.
+  The gate's dominant behaviour is routing guardrail and contract diffs to the human, which is
+  its designed purpose rather than friction. **But 0% is a 22-row measurement on one person's
+  repo, and issues #24 and #30 both record citation-widening false alarms in a field repo that
+  never reached this ledger** — so the 0% is the local rate, not the suite's.
+
+### Compliance — did the work leave a trace
+
+- **run-log rows: 3** — `wai-pr-review` 2 · `wai-retro` 1. Both pr-review runs have matching
+  ledger rows; the retro run has its marker. Nothing in the period ran untraced.
+- **traced share: not derivable** (0 merged PRs with a readable number). Not 100%.
+- **Finding about the suite, not the people:** the ledger and the run-log are both append-only,
+  both written per-run into a versioned file on whatever branch is checked out — the exact design
+  issue #35 filed against `merge-gate.sh`, reported there as four merge conflicts in one day.
+  This period is that issue's second confirmation, and the first where the loss was **silent**.
+
+### Collaboration
+
+not derived — no artifact exists (a question trace is the prerequisite; nothing here is recalled)
+
+### Outcomes (the human's column)
+
+| finding | outcome |
+|---|---|
+| PR #31's squash deleted PR #28's ledger row (1 of 28); run-log row survived | |
+| `open-items.sh` merged-sweep checks commit reachability, not content survival | |
+| `wai-retro/SKILL.md` documents three cwd-wrong invocations (gate-stats exit 2; doctor false-clean + no cadence advisory) | |
+| `traced share` not derivable for the second consecutive retro (squash merges) — issue #24 | |
+| 2 untagged rows (PR #31's own) + 1 `need inspection` (PR #19) outside every rate | |
+
+### ▶ Recommended next
+
+1. **Restore the deleted ledger row** (`wai-implementation`) — re-append PR #28's
+   `2026-08-14T16:45Z` row. An append-only file that lost a row needs the row back, not an edit;
+   PR #21 already set the precedent (*"restore #19's lost gate row"*), which makes this the
+   **second** occurrence of the same loss and the reason to fix the mechanism, not the row.
+2. **Decide the ledger's home** (the human) — issue #35's two honest options: move it to
+   `~/.claude/gate-ledger/<owner>-<repo>.md` like the learning ledger, or keep it in-repo and
+   make the skill say *"this row belongs on `main`"*. This is a guardrail-adjacent design call,
+   so it is yours. Until it is decided, every concurrent branch can drop a row.
+3. **Fix this skill's documented invocations** (`wai-implementation`) — pass the repo root
+   explicitly (`doctor.sh "$REPO_ROOT"`) or state "from the repo root". A retro whose collection
+   step returns `exit 2` publishes a false `not measured`.
+4. **Extend the merged-sweep to content** (`wai-implementation`) — for each merged PR, assert its
+   ledger/run-log rows are present on `origin/HEAD`, not just its merge commit. This is the check
+   that would have caught finding 1 on the day.
+5. **#24** (`wai-retro`) — squash-aware merged-PR derivation, so `traced share` stops being the
+   one number this report cannot produce.
+6. Tag the 3 rows outside the ratios: PR #31 ×2 (this repo's own retro PR) and PR #19
+   (`need inspection`).

--- a/docs/architecture/run-log.md
+++ b/docs/architecture/run-log.md
@@ -24,3 +24,4 @@ a suite update must never touch this file (the same never-eaten guarantee as the
 | 2026-08-16T22:00Z | wai-pr-review | PR #31 | NO-GO |
 | 2026-08-16T22:02Z | wai-pr-review | PR #31 | GO |
 | 2026-08-14T19:45Z | wai-pr-review | PR #28 | NO-GO |
+| 2026-08-18T05:14Z | wai-retro | 2026-08-16 marker -> 2026-08-18 (2 verdicts) | report cut; ledger row lost in a merge race, marker NOT yet planted |


### PR DESCRIPTION
Explicit-request retro (`/wai-retro`). **2 verdicts since the 2026-08-16 marker, threshold 25** — below threshold, legitimate as a request, and the report states the denominator beside every rate.

## What the period produced

**A merge deleted a row from the append-only gate ledger, and the row count went up.**

| | |
|---|---|
| PR #28 merged | 21:51Z, carrying its gate row `2026-08-14T16:45Z \| 28 \| NO-GO` (ledger: 27 rows) |
| PR #31 merged | 21:59Z, from a branch cut **before** #28 — its squash carried the older ledger forward |
| Net | **27 → 28 rows: +2 for #31, −1 for #28** |

`git show ddca5f3 -- docs/architecture/gate-ledger.md` carries the deletion as a literal `-` line, in a file whose own header reads *"APPEND-ONLY. Never edit or delete a past row."* PR #28's **run-log** row survived the same race, so the two append-only files now disagree about whether that run happened.

**`open-items.sh`'s merged-but-unreachable sweep was green throughout** — it asserts every merge *commit* is an ancestor of `origin/HEAD`, which was true. It does not assert the commit's *content* survived a later squash. That sweep exists because of `2026-08-06-merged-but-not-on-main.md`; this is its sibling.

This is the **second** lost ledger row (PR #21 restored #19's), which moves it from a row to fix to a mechanism to decide — [#35](https://github.com/woldinius/wai-skill-suite/issues/35).

## Also recorded

`wai-retro/SKILL.md` documents three invocations *"from this skill's directory"*; all three resolve inputs relative to cwd. `gate-stats.sh` exits 2 (`no ledger`) — which the skill's own fail-closed rule would publish as a false `not measured`. `doctor.sh` audited the skill folder and printed *"no drift that disables a feature"* over a missing catalog and missing gate, and printed **no cadence advisory** — the documented trigger. `contract-lint.sh` is green and correct: it verifies paths resolve from the repo root, never that an invocation runs.

## Verification

`run.sh` 152/0 · `scripts.sh` 163/0 + 6 XFAIL · `numbers-lint --cases 321` exit 0 · ledger 28/4.

## The marker is deliberately not planted

Step 6 would append a report marker, resetting the cadence at 2/25. Two reasons it is left to you: the reset is a judgment call on a period this thin, and appending to the ledger **from a branch is the exact pattern this report just documented losing rows**. Say the word and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)