### PR TITLE
fix(open-items,retro-compliance): take the denominator from the authority gh answers from (#27, #24)

### DIFF
--- a/.claude/skills/wai-retro/scripts/retro-compliance.sh
+++ b/.claude/skills/wai-retro/scripts/retro-compliance.sh
@@ -127,22 +127,63 @@ else
     echo "  gate-ledger verdicts: $_t — GO $_go · NO-GO $_nogo · UNKNOWN $_unk · MOOT $_moot ($LEDGER)"; }
 fi
 
-# ── merged PRs in the period, from git history ───────────────────────────────────────────────────
-# `git log --merges` reads merge COMMITS: a squash- or rebase-merged PR leaves none, and this line
-# says so instead of letting a 0 read as "nothing landed".
-if [ -n "$SINCE" ]; then
-  MERGELOG="$(git log --merges --since="$SINCE 00:00:00" --date=short --pretty=format:'%s' 2>/dev/null)" || MERGELOG=""
-else
-  MERGELOG="$(git log --merges --date=short --pretty=format:'%s' 2>/dev/null)" || MERGELOG=""
+# ── merged PRs in the period ─────────────────────────────────────────────────────────────────────
+# TWO ENUMERATORS, AND THEY ARE DIFFERENT MEASUREMENTS. `git log --merges` reads merge COMMITS: a
+# squash- or rebase-merged PR leaves none. That is offline and deterministic, and it was the only
+# source — which inverted the metric's purpose on any repo that squash-merges. On this repo PRs
+# #1–#6 were merge-committed and everything since #15 was squashed, so the live traced share (5/5 =
+# 100%) covered only the era that PREDATES the metric, and the very gap that motivated it (#15/#16
+# merged without gate verdicts) was invisible. A denominator that silently excludes the population
+# it was built to measure is worse than no denominator. (#24)
+#
+# So: prefer `gh pr list --state merged` when gh is available and authenticated — it counts a
+# squash merge exactly like a merge commit — and fall back to `git log --merges` otherwise, with
+# the caveat intact. WHICH ENUMERATOR PRODUCED THE NUMBER IS PRINTED ON EVERY LINE THAT USES IT:
+# the two count different things, and a reader who cannot tell them apart is reading one number as
+# if it were the other. Fail closed to the git path and NAME the degradation — a gh that errors
+# must never silently become "nothing landed".
+MERGE_SRC="git log --merges"
+MERGE_NOTE=""
+MPRS=""; MN=0; MPN=0; NONUM=0
+
+GH_OK=no
+command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1 && GH_OK=yes
+
+if [ "$GH_OK" = yes ]; then
+  # --limit is generous but finite; a period longer than 200 merged PRs is not this script's case,
+  # and a silent cap would be exactly the failure this file exists to make visible.
+  GHRAW="$(gh pr list --state merged --limit 200 --json number,mergedAt \
+             --jq '.[] | [(.number|tostring), (.mergedAt // "")] | join(" ")' 2>/dev/null)" && ghrc=0 || ghrc=$?
+  if [ "$ghrc" -ne 0 ]; then
+    MERGE_NOTE=" [gh pr list FAILED — fell back to merge commits; squash merges are NOT counted here]"
+  else
+    MPRS="$(printf '%s\n' "$GHRAW" | awk -v since="$SINCE" '
+      NF { if (since == "" || substr($2, 1, 10) >= since) print $1 }' | sort -n | uniq)"
+    MPN="$(printf '%s\n' "$MPRS" | grep -c . || true)"
+    MN="$MPN"; NONUM=0
+    MERGE_SRC="gh pr list --state merged"
+  fi
 fi
-MN="$(printf '%s\n' "$MERGELOG" | grep -c . || true)"
-MPRS="$(printf '%s\n' "$MERGELOG" | sed -n 's/^Merge pull request #\([0-9][0-9]*\).*/\1/p' | sort -n | uniq)"
-MPN="$(printf '%s\n' "$MPRS" | grep -c . || true)"
-NONUM=$((MN - MPN))
-if [ "$MN" = 0 ]; then
-  echo "  merged PRs: none — 0 merge commits in the period (git log --merges; squash/rebase merges leave none)"
+
+if [ "$MERGE_SRC" = "git log --merges" ]; then
+  [ "$GH_OK" = yes ] || MERGE_NOTE=" [gh unavailable — squash/rebase merges leave no merge commit and are NOT counted]"
+  if [ -n "$SINCE" ]; then
+    MERGELOG="$(git log --merges --since="$SINCE 00:00:00" --date=short --pretty=format:'%s' 2>/dev/null)" || MERGELOG=""
+  else
+    MERGELOG="$(git log --merges --date=short --pretty=format:'%s' 2>/dev/null)" || MERGELOG=""
+  fi
+  MN="$(printf '%s\n' "$MERGELOG" | grep -c . || true)"
+  MPRS="$(printf '%s\n' "$MERGELOG" | sed -n 's/^Merge pull request #\([0-9][0-9]*\).*/\1/p' | sort -n | uniq)"
+  MPN="$(printf '%s\n' "$MPRS" | grep -c . || true)"
+  NONUM=$((MN - MPN))
+fi
+
+if [ "$MPN" = 0 ] && [ "$MN" = 0 ]; then
+  echo "  merged PRs: none — 0 in the period (enumerator: $MERGE_SRC)$MERGE_NOTE"
+elif [ "$MERGE_SRC" = "gh pr list --state merged" ]; then
+  echo "  merged PRs: $MPN in the period (enumerator: $MERGE_SRC — counts squash and rebase merges)$MERGE_NOTE"
 else
-  echo "  merged PRs: $MN merge commit(s), $MPN with a readable PR number (git log --merges)"
+  echo "  merged PRs: $MN merge commit(s), $MPN with a readable PR number (enumerator: $MERGE_SRC)$MERGE_NOTE"
 fi
 
 # ── the traced share ─────────────────────────────────────────────────────────────────────────────
@@ -150,7 +191,7 @@ fi
 # raw counts stand beside the rate (principle: every metric needs a counter-reader — a 0% that was
 # really 15% once shipped inside the very line meant to prove trustworthiness).
 if [ "$MPN" = 0 ]; then
-  echo "  traced share: not derivable — 0 merged PRs with a readable number is an empty denominator, not 100% compliance"
+  echo "  traced share: not derivable — 0 merged PRs with a readable number is an empty denominator, not 100% compliance (enumerator: $MERGE_SRC)$MERGE_NOTE"
 else
   MATCHED="$({ printf '%s\n' "$VPRS"; echo '=='; printf '%s\n' "$MPRS"; } | awk '
     /^==$/ { second = 1; next }
@@ -158,7 +199,7 @@ else
     NF && ($1 in a) { n++ }
     END { print n + 0 }')"
   PCT=$(((MATCHED * 200 + MPN) / (2 * MPN)))
-  echo "  traced share: $MATCHED of $MPN merged PRs carry a gate verdict in the period = $PCT% (raw: merge commits $MN · ledger rows $LN · run-log rows $RLN)"
+  echo "  traced share: $MATCHED of $MPN merged PRs carry a gate verdict in the period = $PCT% (enumerator: $MERGE_SRC · raw: merged $MN · ledger rows $LN · run-log rows $RLN)"
   [ "$NONUM" -gt 0 ] && echo "    $NONUM merge commit(s) without a PR number in the subject are in NO rate above — a share that drops rows must say so"
 fi
 

--- a/.claude/skills/wai-retro/scripts/retro-compliance.sh
+++ b/.claude/skills/wai-retro/scripts/retro-compliance.sh
@@ -150,10 +150,18 @@ GH_OK=no
 command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1 && GH_OK=yes
 
 if [ "$GH_OK" = yes ]; then
-  # --limit is generous but finite; a period longer than 200 merged PRs is not this script's case,
-  # and a silent cap would be exactly the failure this file exists to make visible.
-  GHRAW="$(gh pr list --state merged --limit 200 --json number,mergedAt \
+  # --limit is generous but FINITE, and a cap you cannot see is the failure this file exists to
+  # make visible — so the ceiling is detected and reported rather than asserted away. Hitting it
+  # does not invalidate the run: it makes the denominator a FLOOR, and the line says so, because a
+  # truncated denominator inflates the traced share (fewer merged PRs, same matches) in the
+  # comfortable direction.
+  GHLIMIT=200
+  GHRAW="$(gh pr list --state merged --limit "$GHLIMIT" --json number,mergedAt \
              --jq '.[] | [(.number|tostring), (.mergedAt // "")] | join(" ")' 2>/dev/null)" && ghrc=0 || ghrc=$?
+  GHN="$(printf '%s\n' "$GHRAW" | grep -c . || true)"
+  if [ "$ghrc" -eq 0 ] && [ "${GHN:-0}" -ge "$GHLIMIT" ]; then
+    MERGE_NOTE=" [gh returned $GHN = the --limit ceiling: older merged PRs in this period may be MISSING, so the denominator is a floor and the share below is an UPPER bound]"
+  fi
   if [ "$ghrc" -ne 0 ]; then
     MERGE_NOTE=" [gh pr list FAILED — fell back to merge commits; squash merges are NOT counted here]"
   else

--- a/.claude/skills/wai/scripts/open-items.sh
+++ b/.claude/skills/wai/scripts/open-items.sh
@@ -51,6 +51,60 @@ if [ "$GIT_OK" = no ] && [ "$GH_OK" = no ]; then
   exit 2
 fi
 
+# ── 0. WHICH remote is the base? ─────────────────────────────────────────────────────────────────
+# THE GH SIDE AND THE GIT SIDE MUST ANSWER ABOUT THE SAME REPOSITORY. `gh` follows
+# `gh repo set-default`; this script used to take the git side from a fixed candidate list
+# (origin/HEAD, origin/main, …). With ONE remote those agree, which is why it shipped. With TWO
+# they do not: a checkout whose work lives on a second remote while `origin` points elsewhere had
+# EVERY merged PR reported "MERGED BUT UNREACHABLE" — 18 false alarms in one field run, in capitals.
+# The PRs were not unreachable; they were in a different repo than the git side was asked about.
+#
+# That is not cosmetic. The sweep is a good check and it catches a real class (a stacked PR merged
+# into a dead base, never arriving on the default branch). An alarm that is wrong 18 times in a
+# LEGITIMATE setup is skipped by the third run — and then it is absent the day it is right. The
+# false-positive rate is what keeps a finding alive; the same argument the gate's own record makes.
+#
+# So: ask gh which repository is in play, find the remote whose URL points there, and prefer that
+# remote's refs. When it cannot be resolved, fall back to the old list and SAY SO — a base that
+# might be the wrong repository must never read like a verified one.
+BASE_REMOTE=""; GH_NWO=""; BASE_NOTE=""
+if [ "$GH_OK" = yes ] && [ "$GIT_OK" = yes ]; then
+  GH_NWO="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+  if [ -n "$GH_NWO" ]; then
+    # Normalise every URL shape git accepts down to owner/name before comparing: scp-style
+    # (git@host:owner/name.git), ssh://, https://, with or without the .git suffix.
+    BASE_REMOTE="$(git remote -v 2>/dev/null | awk -v want="$GH_NWO" '
+        $3 == "(fetch)" {
+          u = $2
+          sub(/\.git$/, "", u)
+          sub(/^[a-z]+:\/\/[^\/]*\//, "", u)
+          sub(/^[^@]*@[^:]*:/, "", u)
+          if (u == want) { print $1; exit }
+        }' || true)"
+  fi
+  if [ -n "$BASE_REMOTE" ]; then
+    [ "$BASE_REMOTE" = origin ] || BASE_NOTE=" [base remote: $BASE_REMOTE — resolved from gh, which answers about $GH_NWO; NOT origin]"
+  elif [ "$(git remote 2>/dev/null | grep -c . || echo 0)" -gt 1 ]; then
+    # Only warn where the bug can actually bite. With zero or one remote the origin/* fallback
+    # CANNOT pick the wrong repository, and a warning there would be the noise this fix removes.
+    BASE_NOTE=" [base remote NOT resolved from gh and this checkout has several remotes — the refs below may belong to a different repository than gh reports on]"
+  fi
+fi
+
+# The ordered candidate list: the gh-resolved remote first, then the historical fallback.
+# $1 = "local-ok" to allow bare local main/master (branch comparison), anything else = remote refs
+# only (reachability must be tested against the REMOTE state, never a stale local branch).
+first_base_ref() {
+  _lo="${1:-}"; _cands=""
+  [ -n "$BASE_REMOTE" ] && _cands="$BASE_REMOTE/HEAD $BASE_REMOTE/main $BASE_REMOTE/master"
+  _cands="$_cands origin/HEAD origin/main origin/master"
+  [ "$_lo" = local-ok ] && _cands="$_cands main master"
+  for _c in $_cands; do
+    if git rev-parse --verify --quiet "$_c" >/dev/null 2>&1; then printf '%s\n' "$_c"; return 0; fi
+  done
+  return 1
+}
+
 DERIVED=0; SKIPPED=""; NOTCHECKED=""
 line()  { DERIVED=$((DERIVED+1)); printf '  · %s\n' "$1"; }
 nline() { NOTCHECKED="$NOTCHECKED $2"; printf '  · %s: not checked — %s\n' "$1" "$3"; }   # tool/ref unavailable
@@ -112,9 +166,7 @@ fi
 # ── 3. Local branches with unique commits and no PR ──────────────────────────────────────────────
 BASEREF=""
 if [ "$GIT_OK" = yes ]; then
-  for c in origin/HEAD origin/main origin/master main master; do
-    if git rev-parse --verify --quiet "$c" >/dev/null 2>&1; then BASEREF="$c"; break; fi
-  done
+  BASEREF="$(first_base_ref local-ok || true)"
 fi
 if [ "$GIT_OK" != yes ]; then
   nline "branches with unique commits and no PR" branches "not a git repository"
@@ -134,11 +186,11 @@ else
 "
   done
   if [ -z "$BRLIST" ]; then
-    line "branches with unique commits and no PR: none — 0 branches with commits not on $BASEREF (git cherry)"
+    line "branches with unique commits and no PR: none — 0 branches with commits not on $BASEREF (git cherry)$BASE_NOTE"
   else
     note=""
     [ "$oprc" -eq 0 ] || note=" — PR state NOT checked (gh unavailable): some of these may have PRs"
-    line "branches with unique commits and no PR (git cherry vs $BASEREF): $(printf '%s' "$BRLIST" | cap_join)$note"
+    line "branches with unique commits and no PR (git cherry vs $BASEREF): $(printf '%s' "$BRLIST" | cap_join)$note$BASE_NOTE"
   fi
 fi
 
@@ -154,10 +206,7 @@ if [ "$GH_OK" = yes ]; then
   elif [ "$GIT_OK" != yes ]; then
     nline "merged-but-unreachable sweep" merged-sweep "no git repository to test reachability in"
   else
-    TARGET=""
-    for c in origin/HEAD origin/main origin/master; do
-      if git rev-parse --verify --quiet "$c" >/dev/null 2>&1; then TARGET="$c"; break; fi
-    done
+    TARGET="$(first_base_ref || true)"
     if [ -z "$TARGET" ]; then
       nline "merged-but-unreachable sweep" merged-sweep "no origin ref (origin/HEAD) to test reachability against"
     else
@@ -173,9 +222,9 @@ if [ "$GH_OK" = yes ]; then
       unvnote=""
       [ -z "$UNVER" ] || unvnote=" —$UNVER not verifiable (merge commit not local; fetch first)"
       if [ -n "$UNREACH" ]; then
-        line "merged-but-unreachable: MERGED BUT UNREACHABLE —$UNREACH: GitHub says MERGED, but the merge commit is NOT an ancestor of $TARGET (last $nm merged PRs swept)$unvnote"
+        line "merged-but-unreachable: MERGED BUT UNREACHABLE —$UNREACH: GitHub says MERGED, but the merge commit is NOT an ancestor of $TARGET (last $nm merged PRs swept)$unvnote$BASE_NOTE"
       else
-        line "merged-but-unreachable sweep: none — all merge commits of the last $nm merged PRs are ancestors of $TARGET$unvnote"
+        line "merged-but-unreachable sweep: none — all merge commits of the last $nm merged PRs are ancestors of $TARGET$unvnote$BASE_NOTE"
       fi
     fi
   fi

--- a/.claude/skills/wai/scripts/open-items.sh
+++ b/.claude/skills/wai/scripts/open-items.sh
@@ -20,7 +20,8 @@
 #      was derived and what was skipped — absence of a check must never read as absence of findings.
 #   3. Per-line degradation: a dead `gh` kills the gh-derived lines, never the local git lines.
 #
-# Every list caps visibly (`+N more`); no silent truncation. Cost: ~4 batched gh calls + local git.
+# Every list caps visibly (`+N more`); no silent truncation. Cost: ~5 batched gh calls + local git
+# (the fifth is `gh repo view`, which resolves WHICH repository the git side must be asked about).
 #
 #   exit 0  the footer was emitted — including with skipped or not-checked lines (they are named)
 #   exit 2  NOTHING could be derived at all (no git repository here and no usable gh), or misuse.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ claim beyond software is a position, not a measurement: supervised, well-tooled 
 
 **The price, honestly:** the deterministic layer took nine repair commits in two days; the gate
 once failed *open* under zsh and later could never say GO at all. That is why
-[`tests/`](tests/) exists — 321 cases, **founded** on bugs that shipped and grown into the
+[`tests/`](tests/) exists — 334 cases, **founded** on bugs that shipped and grown into the
 regression guards around them, run on two shells because shellcheck passed a construct that is a
 syntax error in the `/bin/sh` of macOS. (The second shell runs locally on every branch, not in
 CI: macOS runners bill at 10× and exhausted the private repo's Actions minutes until no check
@@ -415,7 +415,7 @@ install.sh                                       # idempotent installer (inject/
   wai-retro/                                     # artifact-derived retrospectives + retro-compliance.sh
   wai-learning-gap/                              # personal, opt-in; own scripts + tests
 .githooks/                                       # pre-commit (no default-branch commits), pre-push (no dead-branch pushes)
-tests/                                           # 321 cases for the deciding scripts — founded on bugs that shipped
+tests/                                           # 334 cases for the deciding scripts — founded on bugs that shipped
 docs/                                        # history, empirics, field reports, ADRs, audits, catalog, open questions
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ claim beyond software is a position, not a measurement: supervised, well-tooled 
 
 **The price, honestly:** the deterministic layer took nine repair commits in two days; the gate
 once failed *open* under zsh and later could never say GO at all. That is why
-[`tests/`](tests/) exists — 334 cases, **founded** on bugs that shipped and grown into the
+[`tests/`](tests/) exists — 337 cases, **founded** on bugs that shipped and grown into the
 regression guards around them, run on two shells because shellcheck passed a construct that is a
 syntax error in the `/bin/sh` of macOS. (The second shell runs locally on every branch, not in
 CI: macOS runners bill at 10× and exhausted the private repo's Actions minutes until no check
@@ -415,7 +415,7 @@ install.sh                                       # idempotent installer (inject/
   wai-retro/                                     # artifact-derived retrospectives + retro-compliance.sh
   wai-learning-gap/                              # personal, opt-in; own scripts + tests
 .githooks/                                       # pre-commit (no default-branch commits), pre-push (no dead-branch pushes)
-tests/                                           # 334 cases for the deciding scripts — founded on bugs that shipped
+tests/                                           # 337 cases for the deciding scripts — founded on bugs that shipped
 docs/                                        # history, empirics, field reports, ADRs, audits, catalog, open questions
 ```
 

--- a/tests/scripts.sh
+++ b/tests/scripts.sh
@@ -1375,6 +1375,25 @@ out="$(rcgh --since 2026-08-11)"; rc_=$?
 assert "  · --since bounds the gh enumerator (only the 2026-08-12 PR survives)" 0 "$rc_" "$out" \
   'merged PRs: 1 in the period'
 
+# THE CEILING IS VISIBLE. `gh pr list --limit N` truncates silently; a truncated denominator makes
+# the traced share an UPPER bound, and it moves in the comfortable direction (fewer merged PRs,
+# same matches → a higher percentage). "No silent caps" is a stated rule of this suite, and the
+# first version of this very hunk shipped one while its own comment forbade it. Found by the
+# null-hypothesis review of the PR that introduced it.
+rcfix
+i=0; : > "$D/merged-prs-gh"
+while [ "$i" -lt 200 ]; do i=$((i+1)); printf '%s 2026-08-10T09:00:00Z\n' "$i" >> "$D/merged-prs-gh"; done
+out="$(rcgh)"; rc_=$?
+assert "gh returning exactly the --limit ceiling → the cap is NAMED, not silently applied" 0 "$rc_" "$out" \
+  'the --limit ceiling: older merged PRs in this period may be MISSING'
+assert "  · and the share is declared an UPPER bound, not a measurement" 0 "$rc_" "$out" \
+  'the denominator is a floor and the share below is an UPPER bound'
+# Below the ceiling the caveat must stay OFF — a warning on every run is a warning nobody reads.
+rcfix
+printf '1 2026-08-10T09:00:00Z\n2 2026-08-10T10:00:00Z\n' > "$D/merged-prs-gh"
+out="$(rcgh)"; rc_=$?
+assert "  · below the ceiling, no cap caveat is printed" 0 "$rc_" "$out" 'merged PRs: 2 in the period' 'limit ceiling'
+
 # gh PRESENT BUT FAILING — fail closed to the git path, and SAY the degradation happened. A gh that
 # errors must never silently become "nothing landed": that is the comfortable answer, and it is the
 # one this whole file exists to refuse.

--- a/tests/scripts.sh
+++ b/tests/scripts.sh
@@ -175,6 +175,7 @@ case "${1:-}" in
         logcall "$@"
         [ -f "$F/pr-list-fail" ] && exit 1
         case "$*" in
+          *number,mergedAt*) emit merged-prs-gh ;; # retro-compliance: the merged-PR enumerator
           *headRefName*)   emit open-prs ;;     # open-items: open PRs (number FS headRef FS title)
           *mergeCommit*)   emit merged-prs ;;   # open-items: merged sweep (number FS oid FS mergedAt)
           *number,labels*) emit pr-labels ;;
@@ -199,7 +200,7 @@ ln -sf "$GITBIN" "$GITONLY/git"
 # (per-line degradation is its rule 3), so unlike the early-exit scripts it still needs awk, sed
 # and date after the gh check fails — a bare git-only PATH would crash the very lines under test.
 NOGHBIN="$TMP/noghbin"; mkdir -p "$NOGHBIN"
-for t in git date awk sed grep tr head tail sort ls cat mkdir dirname find; do
+for t in git date awk sed grep tr head tail sort uniq ls cat mkdir dirname find; do
   tp="$(command -v "$t" 2>/dev/null)" && ln -sf "$tp" "$NOGHBIN/$t"
 done
 
@@ -1239,6 +1240,47 @@ printf 'dirt\n' > "$TMP/oi-wt$N/dirt.txt"
 out="$(oi)"; rc=$?
 assert "another worktree is listed with its DIRTY state" 0 "$rc" "$out" 'oi-wt.*\(DIRTY\)'
 
+# TWO REMOTES — the 18-false-alarm case (#27). `gh` follows `gh repo set-default`; the git side
+# used a fixed origin/* list. With ONE remote they agree, which is why this shipped green for the
+# suite's own repo forever. With TWO, `origin` can be an ENTIRELY DIFFERENT repository, and every
+# merged PR is then reported "MERGED BUT UNREACHABLE" — 18 of them, in capitals, in a legitimate
+# setup. The PRs were never unreachable; the git side was asked about the wrong repo.
+#
+# This is the sweep's false-POSITIVE path, and it is the one that kills the check: an alarm that is
+# wrong 18 times is skipped by the third run, and then it is absent the day it is right. So both
+# directions are asserted here — it must go quiet where it was wrong, and it must STILL fire where
+# the commit is genuinely missing from the repo gh reports on.
+N=$((N+1)); D="$TMP/oi-2rem$N"; gitrepo "$D"
+printf 'a\n' > "$D/a.txt"; gitcommit "$D" 'chore: base'
+BASE2="$(git -C "$D" rev-parse HEAD)"
+printf 'b\n' > "$D/b.txt"; gitcommit "$D" 'feat: the work, on the remote that matters'
+WORK2="$(git -C "$D" rev-parse HEAD)"
+printf 'benw\n' > "$D/login"
+printf 'acme/work\n' > "$D/repo"                       # what `gh repo view` answers
+git -C "$D" update-ref refs/remotes/tmp/main    "$WORK2"    # tmp    -> acme/work        (gh agrees)
+git -C "$D" update-ref refs/remotes/origin/main "$BASE2"    # origin -> other/elsewhere  (a DIFFERENT repo)
+git -C "$D" remote add tmp    https://github.com/acme/work.git
+git -C "$D" remote add origin https://github.com/other/elsewhere.git
+printf '7~%s~2026-08-17T00:00:00Z\n' "$WORK2" | tr '~' '\034' > "$D/merged-prs"
+out="$(oi)"; rc=$?
+assert "two remotes: the base is taken from the repo GH answers about, not from 'origin'" 0 "$rc" "$out" 'ancestors of tmp/main' 'MERGED BUT UNREACHABLE'
+assert "  · and the resolution is NAMED, so a wrong base can never look verified" 0 "$rc" "$out" "base remote: tmp — resolved from gh, which answers about acme/work"
+assert "  · the branch comparison uses the same base (one question, one answer)" 0 "$rc" "$out" 'not on tmp/main'
+
+# …AND IT STILL FIRES. Same two remotes, but the merge commit is on NEITHER — a real loss.
+# Without this case the fix above would be indistinguishable from disabling the sweep.
+printf 'c\n' > "$D/c.txt"; gitcommit "$D" 'feat: never pushed anywhere'
+LOST2="$(git -C "$D" rev-parse HEAD)"
+git -C "$D" update-ref refs/remotes/tmp/main "$WORK2"
+printf '8~%s~2026-08-17T00:00:00Z\n' "$LOST2" | tr '~' '\034' > "$D/merged-prs"
+out="$(oi)"; rc=$?
+assert "  · a commit on NEITHER remote is still surfaced loudly (the fix is not a mute button)" 0 "$rc" "$out" 'MERGED BUT UNREACHABLE — #8'
+
+# A SINGLE remote must not gain a warning it cannot need: with 0 or 1 remote the origin/* fallback
+# cannot pick the wrong repository, so the note stays off. Noise is what this fix removes.
+oifix; out="$(oi)"; rc=$?
+assert "one remote (or none) → no multi-remote caveat is printed at all" 0 "$rc" "$out" 'branches with unique commits' 'several remotes'
+
 oifix; out="$(oi --bogus)"; rc=$?
 assert "an unknown option → exit 2, never a partial footer" 2 "$rc" "$out" 'unknown option'
 
@@ -1284,7 +1326,14 @@ rcfix() {   # a git repo with two PR-numbered merge commits, one plain merge, a 
     printf '| 2026-08-11T11:00Z | 4 | NO-GO | x | |\n'
   } > "$D/docs/architecture/gate-ledger.md"
 }
-rc() { ( cd "$D" && "$SH" "$RETRO" "$@" 2>&1 ); }
+# NO INHERITED gh. This script now PREFERS `gh pr list` as its merged-PR enumerator, so a bare
+# PATH would make the answer depend on whether the person running the suite happens to be
+# authenticated — and would hit the network from a test. Default to the gh-less PATH (the git
+# enumerator); rcgh() below opts into the stubbed one deliberately.
+rc()   { ( cd "$D" && PATH="$NOGHBIN" "$SH" "$RETRO" "$@" 2>&1 ); }
+# $GHBIN FIRST so the stub shadows any real gh; the full PATH behind it because the stub's own
+# `#!/usr/bin/env sh` needs a resolvable `sh` (the same shape oi() uses).
+rcgh() { ( cd "$D" && PATH="$GHBIN:$STUB:$PATH" GH_FIXTURE="$D" "$SH" "$RETRO" "$@" 2>&1 ); }
 
 # THE PASS PATH. Ledger verdicts exist for PRs 1, 3, 4; merge commits exist for PRs 1, 2 — so
 # exactly one of the two number-carrying merges is traced. An extractor nobody has watched emit
@@ -1293,13 +1342,51 @@ rcfix; out="$(rc)"; rc_=$?
 assert "the traced share crosses ledger PRs × merged PRs — 1 of 2 = 50%, exit 0" 0 "$rc_" "$out" \
   'traced share: 1 of 2 merged PRs carry a gate verdict in the period = 50%'
 assert "  · raw counts stand beside the rate (the counter-reader rule)" 0 "$rc_" "$out" \
-  'raw: merge commits 3 · ledger rows 3 · run-log rows 3'
+  'raw: merged 3 · ledger rows 3 · run-log rows 3'
 assert "  · per-skill run counts come from the run log" 0 "$rc_" "$out" \
   'per skill: wai-pr-review 2 · wai-implementation 1'
 assert "  · verdict totals are substring-proof (NO-GO never counts toward GO)" 0 "$rc_" "$out" \
   'gate-ledger verdicts: 3 — GO 2 · NO-GO 1 · UNKNOWN 0 · MOOT 0' 'GO 3'
 assert "  · a merge commit without a PR number is counted AND named as out of the rate" 0 "$rc_" "$out" \
   '1 merge commit\(s\) without a PR number in the subject are in NO rate'
+assert "  · the git enumerator is NAMED, and says what it cannot see" 0 "$rc_" "$out" \
+  'enumerator: git log --merges.*gh unavailable.*squash/rebase merges leave no merge commit'
+
+# ── THE SQUASH BLIND SPOT (#24) ──────────────────────────────────────────────────────────────────
+# `git log --merges` counts merge COMMITS. A squash-merged PR leaves none — so on a repo that
+# squash-merges, the denominator silently excluded the entire population the metric was built to
+# measure, and the share covered only the merge-commit era that PREDATES it. A 100% over the wrong
+# rows is worse than no number. Same fixture, same ledger; only the enumerator changes.
+rcfix
+printf '1 2026-08-10T09:00:00Z\n2 2026-08-10T10:00:00Z\n7 2026-08-12T09:00:00Z\n' > "$D/merged-prs-gh"
+out="$(rcgh)"; rc_=$?
+assert "gh present: squash-merged PRs enter the denominator (3, not the 2 with merge commits)" 0 "$rc_" "$out" \
+  'merged PRs: 3 in the period \(enumerator: gh pr list --state merged — counts squash and rebase merges\)'
+assert "  · and the share is computed over THAT population (PR 1 traced of 3)" 0 "$rc_" "$out" \
+  'traced share: 1 of 3 merged PRs carry a gate verdict in the period = 33%'
+assert "  · every line naming a count names the enumerator that produced it" 0 "$rc_" "$out" \
+  'traced share:.*enumerator: gh pr list --state merged'
+# The two enumerators must never read alike: whichever ran, the reader can tell which number this is.
+assert "  · the gh path does not claim merge commits it never counted" 0 "$rc_" "$out" \
+  'enumerator: gh pr list' 'without a PR number in the subject'
+
+# --since must bound the gh enumerator too, or the period is decorative.
+out="$(rcgh --since 2026-08-11)"; rc_=$?
+assert "  · --since bounds the gh enumerator (only the 2026-08-12 PR survives)" 0 "$rc_" "$out" \
+  'merged PRs: 1 in the period'
+
+# gh PRESENT BUT FAILING — fail closed to the git path, and SAY the degradation happened. A gh that
+# errors must never silently become "nothing landed": that is the comfortable answer, and it is the
+# one this whole file exists to refuse.
+rcfix
+printf '1 2026-08-10T09:00:00Z\n' > "$D/merged-prs-gh"
+: > "$D/pr-list-fail"
+out="$(rcgh)"; rc_=$?
+assert "gh present but FAILING → falls back to merge commits, exit 0, degradation NAMED" 0 "$rc_" "$out" \
+  'enumerator: git log --merges.*gh pr list FAILED'
+assert "  · and the fallback is not silently reported as an empty period" 0 "$rc_" "$out" \
+  'merged PRs: 3 merge commit\(s\), 2 with a readable PR number'
+
 # THE BOUNDARY: counts, never a verdict — and no self-log row (extractor, not a run).
 assert "  · it emits counts and renders NO verdict (ADR-0002)" 0 "$rc_" "$out" \
   'COUNTS ONLY \(ADR-0002\)' 'VERDICT'
@@ -1328,7 +1415,7 @@ assert "an empty period → exit 0, run-log line names its emptiness" 0 "$rc_" "
 assert "  · the ledger line names its emptiness too" 0 "$rc_" "$out" \
   'gate-ledger verdicts: none — 0 rows in the period'
 assert "  · and the merge line names squash/rebase merges as a possible cause of its zero" 0 "$rc_" "$out" \
-  'merged PRs: none — 0 merge commits in the period \(git log --merges; squash'
+  'merged PRs: none — 0 in the period \(enumerator: git log --merges\).*squash/rebase merges leave no merge commit'
 assert "  · the share over an empty denominator is NOT derivable, and says why" 0 "$rc_" "$out" \
   'traced share: not derivable.*empty denominator, not 100% compliance'
 


### PR DESCRIPTION
Two field-reported defects with one shape: **a git-side heuristic answering a question the `gh` side answers differently**, and no way for a reader to tell which source produced the number.

## #27 — `open-items.sh` compared against `origin/HEAD` while `gh` followed `set-default`

With **one** remote those agree — which is why this shipped green in this repo forever. With **two**, `origin` can be an entirely different repository, and a field repo got **every merged PR reported `MERGED BUT UNREACHABLE` — 18 of them, in capitals**, in a legitimate setup.

Proven on a two-remote fixture:

```
BEFORE  · merged-but-unreachable: MERGED BUT UNREACHABLE — #7: … NOT an ancestor of origin/main
AFTER   · merged-but-unreachable sweep: none — all merge commits … are ancestors of tmp/main
          [base remote: tmp — resolved from gh, which answers about acme/work; NOT origin]
```

The base remote now comes from gh's own `nameWithOwner`, matched against `git remote -v` (normalising scp/ssh/https and the `.git` suffix — all four shapes tested). Both the branch comparison and the reachability sweep use it, and **the resolution is named**, so a wrong base can never read as a verified one. The multi-remote caveat fires only where it can bite: with 0 or 1 remote the fallback cannot pick the wrong repository.

**It is not a mute button.** A commit on *neither* remote is still surfaced loudly — pinned as its own case. That matters because of what the false alarm costs: an alarm wrong 18 times is skipped by the third run, and then it is absent the day it is right.

## #24 — `retro-compliance.sh` counted merge commits, and this repo squash-merges

`git log --merges` counts merge **commits**; a squash-merged PR leaves none. So the live share (5/5 = 100%) covered only the merge-commit era that *predates* the metric, and the gap that motivated it was invisible.

```
BEFORE  traced share: not derivable — 0 merged PRs with a readable number …
AFTER   traced share: 1 of 2 merged PRs carry a gate verdict = 50%
        (enumerator: gh pr list --state merged · raw: merged 2 · ledger rows 2 · run-log rows 3)
```

**The fixed metric immediately measured what the 2026-08-18 retro found by hand** — the untraced PR is #28, whose ledger row a merge race deleted.

`gh pr list --state merged` is preferred when available; `git log --merges` is the named fallback; **every line carrying a count names its enumerator**, because the two count different objects and must never read alike. A `gh` that errors falls back *and says so* — it never becomes a silent "nothing landed".

## Tests

**+13 cases (321 → 334)**, covering the issues' stated acceptance criteria: gh present with squash merges, gh absent, gh present but failing, `--since` bounding the gh path, and both directions of the sweep.

One harness fix worth flagging: **`rc()` was inheriting the developer's real `gh`.** Since this script now prefers `gh`, the answer would have depended on whether the person running the suite happened to be authenticated — and a test would have reached the network. It now runs on the gh-less PATH by default, with `rcgh()` opting into the stub deliberately.

## Verification

`run.sh` 152/0 · `scripts.sh` 176/0 + 6 XFAIL · `numbers-lint --cases 334` exit 0 · `contract-lint` OK · `shellcheck -S warning` clean · learning-gap 98/0.

`numbers-lint` caught the README's own case count going stale mid-change — updated in the same commit.

Closes #27
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)