### PR TITLE
fix(scripts): default paths resolve against the repo, not the accident of the cwd (#29 pt.1)

### DIFF
--- a/.claude/skills/wai-architecture-audit/SKILL.md
+++ b/.claude/skills/wai-architecture-audit/SKILL.md
@@ -177,7 +177,7 @@ last audit — don't re-derive a full report when nothing meaningful changed.
    the trackable handles into it. Without `gh`, list the would-be issues with their
    `gh issue create` commands.
    **Log the run before handing back:** `sh ../wai/scripts/run-log.sh "wai-architecture-audit"
-   "<subject>" "<half-sentence outcome>"` (from this skill's directory) — an audit that finds
+   "<subject>" "<half-sentence outcome>"` (from this skill's directory; **one row per subject handled, not one per turn** — a turn that hands back three subjects logs three rows) — an audit that finds
    nothing still writes its row, because that is the run that vanishes today; fail-open: exit 0
    even when the write fails, exit 2 only on misuse (missing arguments).
    **Then derive the closing state:** run `sh ../wai/scripts/open-items.sh` (same directory), paste

--- a/.claude/skills/wai-cicd/SKILL.md
+++ b/.claude/skills/wai-cicd/SKILL.md
@@ -118,7 +118,7 @@ Depending on stack and deploy target (not everything is always needed):
 6. **Output the setup report** — including the **manual server steps** (provision,
    harden, install Docker, set secrets, first deploy).
    **Log the run before handing back:** `sh ../wai/scripts/run-log.sh "wai-cicd" "<subject>"
-   "<half-sentence outcome>"` (from this skill's directory) — a run without a row is invisible
+   "<half-sentence outcome>"` (from this skill's directory; **one row per subject handled, not one per turn** — a turn that hands back three subjects logs three rows) — a run without a row is invisible
    work; fail-open: exit 0 even when the write fails, exit 2 only on misuse (missing arguments).
 
 ## Scan checklist

--- a/.claude/skills/wai-implementation/SKILL.md
+++ b/.claude/skills/wai-implementation/SKILL.md
@@ -120,7 +120,7 @@ truth** (`PAY-*`; tokens are digital goods → iOS StoreKit / Android Play Billi
    **wai-pr-review** on the PR; or the next planned task — and note if
    **wai-architecture-audit** is due.
    **Log the run before handing back:** `sh ../wai/scripts/run-log.sh "wai-implementation"
-   "<subject>" "<half-sentence outcome>"` (from this skill's directory) — a run without a row is
+   "<subject>" "<half-sentence outcome>"` (from this skill's directory; **one row per subject handled, not one per turn** — a turn that hands back three subjects logs three rows) — a run without a row is
    invisible work; fail-open: exit 0 even when the write fails, exit 2 only on misuse (missing args).
    **Then derive the closing state:** run `sh ../wai/scripts/open-items.sh` (same directory), paste
    its output verbatim beneath the ▶ Recommended next block, then give your recommendation — in that

--- a/.claude/skills/wai-mobile-release/SKILL.md
+++ b/.claude/skills/wai-mobile-release/SKILL.md
@@ -106,7 +106,7 @@ Depending on platform (not everything is always needed):
 6. **Output the setup report** — including the **manual store-console steps** (App Store Connect
    app + agreements + IAP products; Play Console app + Data Safety + billing products + tracks).
    **Log the run before handing back:** `sh ../wai/scripts/run-log.sh "wai-mobile-release"
-   "<subject>" "<half-sentence outcome>"` (from this skill's directory) — a run without a row is
+   "<subject>" "<half-sentence outcome>"` (from this skill's directory; **one row per subject handled, not one per turn** — a turn that hands back three subjects logs three rows) — a run without a row is
    invisible work; fail-open: exit 0 even when the write fails, exit 2 only on misuse (missing args).
 
 ## Merge gate & store submission

--- a/.claude/skills/wai-pr-review/scripts/gate-stats.sh
+++ b/.claude/skills/wai-pr-review/scripts/gate-stats.sh
@@ -40,7 +40,10 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
-[ -n "$LEDGER" ] || LEDGER="docs/architecture/gate-ledger.md"
+# Default is REPO-relative (see merge-gate.sh — the writer this reads; resolving from the cwd
+# made a documented invocation report "no ledger" over a repo that had 28 rows, a false blank).
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$LEDGER" ] || LEDGER="${REPO_ROOT:-.}/docs/architecture/gate-ledger.md"
 
 # --mark exists to record that a REPORT was cut. Alone it would plant a marker for a report that
 # never happened — doctor would then count from a lie. Refuse, do not guess.

--- a/.claude/skills/wai-pr-review/scripts/merge-gate.sh
+++ b/.claude/skills/wai-pr-review/scripts/merge-gate.sh
@@ -104,7 +104,17 @@ while [ $# -gt 0 ]; do
   [ $# -gt 0 ] && shift
 done
 
-CATALOG="docs/architecture/quality-attributes.md"
+# DEFAULT PATHS ARE REPO-RELATIVE, NOT CWD-RELATIVE. The documented invocations run the suite's
+# scripts "from this skill's directory"; resolved against the cwd, that produced a FALSE verdict
+# ("no quality catalog" — in a repo that has one) and planted a stray gate-ledger inside
+# .claude/skills/ — the very tree install.sh copies into every target repo (2026-08-18, live).
+# So the default base is the enclosing git worktree; an explicit argument or env override still
+# wins, and outside any repo the cwd stays the base (fixtures and bare dirs keep working).
+# Deliberately --show-toplevel, NOT the --git-common-dir parent: rows belong to the worktree that
+# produced them — consolidating across worktrees changes WHERE state lands, which is issue #35's
+# still-open human decision, not this fix's.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+CATALOG="${REPO_ROOT:-.}/docs/architecture/quality-attributes.md"
 
 REASONS=""
 VERDICT=0                       # 0 go · 1 no-go · 2 unknown
@@ -129,7 +139,7 @@ cap400() { awk '{ if (length($0) <= 400) print; else { s = substr($0, 1, 400); s
 # Losing a row is a data gap; blocking a correct merge because a file was read-only would be a real
 # cost. (ADR-0002; docs/learnings/empirical-test-plan.md §0–1.)
 emit_ledger() {
-  _led="${MERGE_GATE_LEDGER:-docs/architecture/gate-ledger.md}"
+  _led="${MERGE_GATE_LEDGER:-${REPO_ROOT:-.}/docs/architecture/gate-ledger.md}"
   if [ ! -f "$_led" ]; then
     mkdir -p "$(dirname "$_led")" 2>/dev/null || true
     # A quoted heredoc: every line literal — backticks, dashes and all — so nothing is a printf
@@ -440,7 +450,7 @@ fi
 # gate is UNKNOWN and the human merges. There is no path from "I could not classify" to GO — the
 # rule the whole gate lives by. pr-review inherits EX-GDPR for free: it obeys this exit code, it
 # does not re-derive the domain set.
-CONF="docs/architecture/merge-gate.conf"
+CONF="${REPO_ROOT:-.}/docs/architecture/merge-gate.conf"
 EXCL_SH="$(dirname "$0")/../../wai/scripts/excluded-domains.sh"
 if [ ! -f "$CONF" ]; then
   # The gate needs its config to know which paths are contract-domain. Absent conf = it cannot

--- a/.claude/skills/wai-requirements-planning/SKILL.md
+++ b/.claude/skills/wai-requirements-planning/SKILL.md
@@ -169,7 +169,7 @@ human gave you in chat, and note the gap in the plan.
    (`gh issue comment <N>`) and carry the issue number forward so implementation can wire
    `Closes #N` into the PR. Optional — skip cleanly if there is no issue or `gh` is unavailable.
    **Log the run before handing back:** `sh ../wai/scripts/run-log.sh "wai-requirements-planning"
-   "<subject>" "<half-sentence outcome>"` (from this skill's directory) — a run without a row is
+   "<subject>" "<half-sentence outcome>"` (from this skill's directory; **one row per subject handled, not one per turn** — a turn that hands back three subjects logs three rows) — a run without a row is
    invisible work; fail-open: exit 0 even when the write fails, exit 2 only on misuse (missing args).
    **Then derive the closing state:** run `sh ../wai/scripts/open-items.sh` (same directory), paste
    its output verbatim beneath the ▶ Recommended next block, then give your recommendation — in that

--- a/.claude/skills/wai-retro/scripts/retro-compliance.sh
+++ b/.claude/skills/wai-retro/scripts/retro-compliance.sh
@@ -35,7 +35,7 @@ set -u
 if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi
 
 SINCE=""
-ROOT="."
+ROOT=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --since)   [ $# -ge 2 ] && [ -n "${2:-}" ] || { echo "retro-compliance: --since needs a date (YYYY-MM-DD)" >&2; exit 2; }
@@ -47,6 +47,12 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
+# Default root = the enclosing git worktree (doctor.sh carries the incident); explicit arg wins
+# — including an explicit "." meaning "this directory, literally". Outside a repo, cwd.
+if [ -z "$ROOT" ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  ROOT="${REPO_ROOT:-.}"
+fi
 case "$SINCE" in
   '') ;;
   [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;

--- a/.claude/skills/wai-testing/SKILL.md
+++ b/.claude/skills/wai-testing/SKILL.md
@@ -134,7 +134,7 @@ sandbox/fakes.
    (§*Where a finding lands*): a gap you neither closed nor deliberately accepted is **filed**,
    not mentioned in passing. Close with **▶ Recommended next**.
    **Log the run before handing back:** `sh ../wai/scripts/run-log.sh "wai-testing" "<subject>"
-   "<half-sentence outcome>"` (from this skill's directory) — a run without a row is invisible
+   "<half-sentence outcome>"` (from this skill's directory; **one row per subject handled, not one per turn** — a turn that hands back three subjects logs three rows) — a run without a row is invisible
    work; fail-open: exit 0 even when the write fails, exit 2 only on misuse (missing arguments).
    **Then derive the closing state:** run `sh ../wai/scripts/open-items.sh` (same directory), paste
    its output verbatim beneath the ▶ Recommended next block, then give your recommendation — in that

--- a/.claude/skills/wai/scripts/doctor.sh
+++ b/.claude/skills/wai/scripts/doctor.sh
@@ -43,7 +43,12 @@
 set -u
 if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi
 
-ROOT="${1:-.}"
+# The default root is the enclosing git worktree, not the cwd: run "from this skill's
+# directory" (as documented), a cwd default audited the SKILL FOLDER as if it were the repo and
+# printed "no drift" over a missing catalog — a false clean, with no cadence advisory at all.
+# An explicit argument still wins; outside a git repo the cwd stays the base.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+ROOT="${1:-${REPO_ROOT:-.}}"
 # Cannot enter the repo ⇒ nothing below was checked. That is state 2, and it is the ONE case where
 # saying "no drift" would be a lie of omission rather than a finding.
 cd "$ROOT" 2>/dev/null || { echo "doctor: cannot cd to '$ROOT'" >&2; exit 2; }

--- a/.claude/skills/wai/scripts/excluded-domains.sh
+++ b/.claude/skills/wai/scripts/excluded-domains.sh
@@ -84,8 +84,12 @@ set -u
 # were launched under zsh, re-exec under sh. (Same guard as merge-gate.sh, for the same reason.)
 if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi
 
-MERGE_CONF="${EXCLUDED_DOMAINS_MERGE_CONF:-docs/architecture/merge-gate.conf}"
-COORD_CONF="${EXCLUDED_DOMAINS_COORD_CONF:-docs/architecture/coordination.conf}"
+# Default paths are REPO-relative, not cwd-relative (merge-gate.sh carries the incident that
+# forced this; same rule here so the two halves of one gate read the same files). Overrides win;
+# outside a git repo the cwd stays the base. --show-toplevel on purpose — see merge-gate.sh.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+MERGE_CONF="${EXCLUDED_DOMAINS_MERGE_CONF:-${REPO_ROOT:-.}/docs/architecture/merge-gate.conf}"
+COORD_CONF="${EXCLUDED_DOMAINS_COORD_CONF:-${REPO_ROOT:-.}/docs/architecture/coordination.conf}"
 
 # --- The guardrail FLOOR — hardcoded here, NOT configurable --------------------------------------
 # Byte-for-byte the same floor merge-gate.sh §5 carries, and for the same reason: if it lived in the

--- a/.claude/skills/wai/scripts/open-items.sh
+++ b/.claude/skills/wai/scripts/open-items.sh
@@ -33,7 +33,10 @@
 set -u
 if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi
 
-ROOT="${1:-.}"
+# Default root = the enclosing git worktree, not the cwd (doctor.sh carries the false-clean
+# incident that forced this; same rule here). An explicit argument wins; outside a repo, cwd.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+ROOT="${1:-${REPO_ROOT:-.}}"
 case "$ROOT" in -*) echo "open-items: unknown option '$ROOT' (usage: sh open-items.sh [repo-root])" >&2; exit 2 ;; esac
 [ $# -le 1 ] || { echo "open-items: at most one argument (repo-root)" >&2; exit 2; }
 cd "$ROOT" 2>/dev/null || { echo "open-items: cannot cd to '$ROOT'" >&2; exit 2; }

--- a/.claude/skills/wai/scripts/run-log.sh
+++ b/.claude/skills/wai/scripts/run-log.sh
@@ -36,8 +36,14 @@
 #           deliberately no exit 1, because this script renders no verdict about anything.
 #
 # Usage: sh run-log.sh <skill> <subject> <outcome>
-#        Appends to docs/architecture/run-log.md (cwd-relative; $RUN_LOG overrides the path — the
-#        same pattern as $MERGE_GATE_LEDGER on the gate ledger).
+#        Appends to <repo-root>/docs/architecture/run-log.md ($RUN_LOG overrides the path — the
+#        same pattern as $MERGE_GATE_LEDGER on the gate ledger; outside a git repo, cwd-relative).
+#
+# WHAT COUNTS AS ONE RUN — defined here because undefined it was measured wrong (issue #29): rows
+# were written per HAND-BACK, so a turn that implemented three subjects logged one row and the
+# count undercounted by a factor nobody could reconstruct. The unit is one row per (skill, subject)
+# completed: a turn that hands back three subjects logs three rows; a re-run on the same subject
+# logs again (two rows for two runs is correct — the gate ledger already counts that way).
 
 set -u
 if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi
@@ -47,7 +53,11 @@ if [ $# -lt 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
   exit 2
 fi
 
-LOG="${RUN_LOG:-docs/architecture/run-log.md}"
+# Default paths are REPO-relative, not cwd-relative (merge-gate.sh carries the incident that
+# forced this; same rule here so the two halves of one gate read the same files). Overrides win;
+# outside a git repo the cwd stays the base. --show-toplevel on purpose — see merge-gate.sh.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+LOG="${RUN_LOG:-${REPO_ROOT:-.}/docs/architecture/run-log.md}"
 
 # One table-safe cell: newlines flattened, pipes escaped, whitespace collapsed — emit_ledger's sed
 # shape — then capped at 120 chars ON A WORD BOUNDARY with a visible '…', for emit_ledger's reason:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ claim beyond software is a position, not a measurement: supervised, well-tooled 
 
 **The price, honestly:** the deterministic layer took nine repair commits in two days; the gate
 once failed *open* under zsh and later could never say GO at all. That is why
-[`tests/`](tests/) exists — 337 cases, **founded** on bugs that shipped and grown into the
+[`tests/`](tests/) exists — 347 cases, **founded** on bugs that shipped and grown into the
 regression guards around them, run on two shells because shellcheck passed a construct that is a
 syntax error in the `/bin/sh` of macOS. (The second shell runs locally on every branch, not in
 CI: macOS runners bill at 10× and exhausted the private repo's Actions minutes until no check
@@ -415,7 +415,7 @@ install.sh                                       # idempotent installer (inject/
   wai-retro/                                     # artifact-derived retrospectives + retro-compliance.sh
   wai-learning-gap/                              # personal, opt-in; own scripts + tests
 .githooks/                                       # pre-commit (no default-branch commits), pre-push (no dead-branch pushes)
-tests/                                           # 337 cases for the deciding scripts — founded on bugs that shipped
+tests/                                           # 347 cases for the deciding scripts — founded on bugs that shipped
 docs/                                        # history, empirics, field reports, ADRs, audits, catalog, open questions
 ```
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -212,6 +212,27 @@ out="$( cd "$D" && PATH="$STUB:$PATH" GH_FIXTURE="$D" MERGE_GATE_LEDGER="$MERGE_
 assert "an unwritable ledger does NOT change the verdict (fail-open logging)" 0 "$rc" "$out" 'VERDICT: GO'
 unset MERGE_GATE_LEDGER
 
+# CWD IS NOT THE REPO (issue #29 sub-fix 2, and the 2026-08-18 live incident). The documented
+# invocation runs this script "from this skill's directory". Resolved against the cwd, that
+# produced a FALSE UNKNOWN ("no quality catalog" — in a repo that has one) AND planted a stray
+# gate-ledger inside .claude/skills/wai-pr-review/ — inside the very tree install.sh copies into
+# every target repo. A cwd bug that seeds a foreign ledger into the install payload is why this
+# case exists. The fixture is a real git repo; the gate is run from the skill directory and must
+# behave EXACTLY as if run from the root: same verdict, ledger at the root, nothing in the payload.
+gfix
+( cd "$D" && git init -q . ) 2>/dev/null
+mkdir -p "$D/.claude/skills/wai-pr-review"
+out="$( cd "$D/.claude/skills/wai-pr-review" && PATH="$STUB:$PATH" GH_FIXTURE="$D" sh "$GATE" 1 2>&1 )"; rc=$?
+assert "run from the skill dir of a git repo → same GO as from the root (no false UNKNOWN)" 0 "$rc" "$out" 'VERDICT: GO'
+if grep -qE '^\| .* \| 1 \| GO \|' "$D/docs/architecture/gate-ledger.md" 2>/dev/null; then
+  ok "  · the ledger row landed at the REPO root"
+else bad "  · the ledger row landed at the REPO root" "no row in $D/docs/architecture/gate-ledger.md"; fi
+if [ ! -e "$D/.claude/skills/wai-pr-review/docs" ]; then
+  ok "  · and NOTHING was planted inside .claude/skills/ (the install payload stays clean)"
+else bad "  · and NOTHING was planted inside .claude/skills/" "stray tree: $D/.claude/skills/wai-pr-review/docs"; fi
+# Outside any git repo the cwd stays the base — every other fixture in this file IS that case
+# (gfix dirs are plain directories), so the fallback is pinned by the whole suite around this.
+
 # Post-merge = MOOT. A gate run on an already-merged PR must say so, not fake a GO/NO-GO — no
 # artefact watches ordering, and this is the one place the gate can. It must short-circuit BEFORE
 # the guardrail/contract checks (which are irrelevant once merged) and record a MOOT row, so an
@@ -285,6 +306,17 @@ N=$((N+1)); SD="$TMP/s$N"; mkdir -p "$SD"
 out="$(sh "$STATS" "$SD/led.md" 2>&1)"; rc=$?
 assert "gate-stats counts the false negative that makes the case" 0 "$rc" "$out" 'FALSE NEGATIVES[^0-9]*1'
 assert "gate-stats reports the 3 emitted verdicts as the denominator" 0 "$rc" "$out" '3 verdict'
+
+# THE FALSE BLANK (2026-08-18): run "from this skill's directory" per its own SKILL.md, the default
+# ledger path resolved against the cwd and gate-stats reported "no ledger" over a repo with 28
+# rows — which the retro's fail-closed rule then publishes as a false `not measured`. The default
+# now resolves against the enclosing worktree; an explicit path (every other case here) still wins.
+N=$((N+1)); SG="$TMP/sg$N"; mkdir -p "$SG/docs/architecture" "$SG/sub/dir"
+( cd "$SG" && git init -q . ) 2>/dev/null
+{ printf '| when | PR | verdict | why | outcome |\n|---|---|---|---|---|\n'
+  printf '| 2026-07-16T09:00Z | 1 | GO | x | ok |\n'; } > "$SG/docs/architecture/gate-ledger.md"
+out="$( cd "$SG/sub/dir" && sh "$STATS" 2>&1 )"; rc=$?
+assert "default ledger path resolves from a SUBDIR to the repo root (no false 'no ledger')" 0 "$rc" "$out" '1 verdict'
 
 # THE 0% THAT WAS 15%. A three-week field ledger (issue #10) tagged with a vocabulary finer than
 # two letters — `ok, besser GO`, `ok, manual fix`, `fp, bug` — and the literal-match parser
@@ -532,6 +564,17 @@ assert "catalog + a POPULATED merge-gate.conf → no drift, exit 0" 0 "$rc" "$ou
 printf 'CONTRACT_PATHS=""\n' > "$DD/docs/architecture/merge-gate.conf"
 out="$(sh "$DOCTOR" "$DD" 2>&1)"; rc=$?
 assert "an EMPTY CONTRACT_PATHS is drift — the gate would pass billing PRs" 1 "$rc" "$out" 'CONTRACT_PATHS'
+
+# THE FALSE CLEAN (2026-08-18): doctor run with no argument "from this skill's directory" audited
+# the SKILL FOLDER as if it were the repo — "no drift" over a missing catalog, and the report-
+# cadence advisory (the retro's trigger) silently absent. The no-arg default is now the enclosing
+# worktree; an explicit argument (every other case in this section) still wins.
+docdir; printf '# cat\n' > "$DD/docs/architecture/quality-attributes.md"
+printf 'CONTRACT_PATHS="src/billing/*"\n' > "$DD/docs/architecture/merge-gate.conf"
+mkdir -p "$DD/.claude/skills/wai"
+( cd "$DD" && git init -q . ) 2>/dev/null
+out="$( cd "$DD/.claude/skills/wai" && sh "$DOCTOR" 2>&1 )"; rc=$?
+assert "no-arg doctor from the skill dir audits the REPO, not the folder (no false clean)" 0 "$rc" "$out" 'merge gate is configured'
 
 # A repo not set up at all (no catalog) → not drift; nothing can drift before setup.
 docdir; out="$(sh "$DOCTOR" "$DD" 2>&1)"; rc=$?

--- a/tests/scripts.sh
+++ b/tests/scripts.sh
@@ -1114,6 +1114,33 @@ else
   bad "  · and the row landed at the override path" "no row in $D/custom/attendance.md"
 fi
 
+# CWD IS NOT THE REPO (issue #29 sub-fix 2). Nine SKILL.md files instruct running this script
+# "from this skill's directory"; with a cwd-relative default every one of those runs planted the
+# row in <skill-dir>/docs/architecture/ — scattered, uncommitted, and (for the suite's own repo)
+# inside the install payload. The default now resolves against the enclosing worktree. The plain
+# non-repo fixtures in every other case of this section pin the cwd fallback.
+N=$((N+1)); D="$TMP/rlgit$N"; gitrepo "$D"
+printf 'x\n' > "$D/f.txt"; gitcommit "$D" 'chore: base'
+mkdir -p "$D/.claude/skills/wai-testing"
+out="$( cd "$D/.claude/skills/wai-testing" && sh "$RUNLOG" wai-testing 'PR #9' 'green' 2>&1 )"; rc=$?
+assert "run from a skill dir inside a git repo → exit 0, row targets the REPO root" 0 "$rc" "$out" 'row appended'
+if grep -q '| wai-testing | PR #9 | green |' "$D/docs/architecture/run-log.md" 2>/dev/null; then
+  ok "  · the row is in <repo-root>/docs/architecture/run-log.md"
+else bad "  · the row is in <repo-root>/docs/architecture/run-log.md" "$(ls -R "$D/.claude" 2>&1)"; fi
+if [ ! -e "$D/.claude/skills/wai-testing/docs" ]; then
+  ok "  · and no stray docs/ tree was planted inside .claude/skills/"
+else bad "  · and no stray docs/ tree was planted inside .claude/skills/" "stray: $D/.claude/skills/wai-testing/docs"; fi
+
+# A PIPE IN THE SUBJECT STAYS ONE CELL (issue #29 sub-fix 3 — pinned, because it was field-reported
+# and the escaping already shipped at f6425f8: a report against an older tree becomes a regression
+# guard, not a re-fix). A raw '|' would split the markdown row and corrupt every parser downstream
+# while still looking like a log.
+rlfix; out="$(rl wai-implementation 'refactor a | b routing' 'done')"; rc=$?
+assert "a '|' in the subject → exit 0, escaped, the row stays one 4-cell line" 0 "$rc" "$out" 'row appended'
+if grep -q '| wai-implementation | refactor a / b routing | done |' "$RL" 2>/dev/null; then
+  ok "  · the pipe was escaped to '/' and the table shape survived"
+else bad "  · the pipe was escaped to '/' and the table shape survived" "$(tail -1 "$RL" 2>&1)"; fi
+
 # FAIL-OPEN PROVEN. An unwritable target still exits 0 — losing a row is a data gap; breaking a
 # finished run over a read-only file would be a real cost (emit_ledger's exact polarity).
 rlfix; out="$( cd "$D" && RUN_LOG=/proc/nonexistent/x/run-log.md sh "$RUNLOG" wai-team '8 issues' '2 PRs' 2>&1 )"; rc=$?


### PR DESCRIPTION
Part 1 of #29 — the three mechanical sub-fixes. The denominator hook (the invocations artifact) is deliberately **not** here; it waits on the design decision flagged in chat (hook-based opt-in vs script-side).

## The incident that sharpened it (2026-08-18, live)

Running `merge-gate.sh 33` *"from this skill's directory"* — the invocation its own SKILL.md documents — produced:

1. a **false UNKNOWN**: *"no docs/architecture/quality-attributes.md"* — in the repo that has one, and
2. a **stray `docs/architecture/gate-ledger.md` planted inside `.claude/skills/wai-pr-review/`** — inside the very tree `install.sh` copies into every target repo. A cwd bug that seeds a foreign ledger into the install payload.

Same class, from the 2026-08-18 retro: `gate-stats` said *"no ledger"* over 28 rows (published as a false `not measured` under the retro's fail-closed rule), and `doctor` audited the skill *folder*, printing **"no drift" over a missing catalog** — with the report-cadence advisory (the retro's own trigger) silently absent. And the field report behind #29: run-log rows scattering across worktrees, staying uncommitted.

## The fix

Seven scripts resolve default paths against the enclosing worktree (`git rev-parse --show-toplevel`): `merge-gate`, `excluded-domains`, `run-log`, `gate-stats`, `doctor`, `open-items`, `retro-compliance`.

- explicit argument / env override **always wins**
- outside any git repo the **cwd stays the base** — fixtures and bare dirs behave exactly as before
- deliberately `--show-toplevel`, **not** the `--git-common-dir` parent: consolidating rows across worktrees changes *where* state lands, which is **#35's still-open human decision**, not this fix's

Net effect: the 16 *"from this skill's directory"* invocations across the SKILL.md files are now **correct as written**, instead of each being a latent false verdict.

Reproduced both retro incidents against the fixed tree: `gate-stats --report` finds the ledger (exit 0), `doctor` audits the repo **and prints the cadence advisory** it previously swallowed.

## Also from #29, same pass

- **sub-fix 1 — "one run" defined:** one row per *(skill, subject)* completed — a turn that hands back three subjects logs three rows. In `run-log.sh`'s header and the six tier-2 SKILL instructions.
- **sub-fix 3 — pipe escaping:** already shipped at `f6425f8`; the field report predates it. **Pinned with a regression case instead of re-fixed** — a report against an older tree becomes a guard, not a change.

## Tests

**+10 cases (337 → 347):** the skill-dir gate run (verdict identical, ledger at root, **payload clean**), the gate-stats subdir case, the doctor false-clean case, the run-log scatter case, and the pipe pin.

`run.sh` 157/0 · `scripts.sh` 184/0 + 6 XFAIL · `numbers-lint --cases 347` exit 0 · `contract-lint` OK · shellcheck clean · learning-gap 98/0.

Refs #29 (part 1 — the issue stays open for the invocation-denominator artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)