### PR TITLE
feat(suite): the four field decisions — ledger home, citation dial, invocation denominator, no-op answer

### DIFF
--- a/.claude/skills/wai-pr-review/scripts/merge-gate.sh
+++ b/.claude/skills/wai-pr-review/scripts/merge-gate.sh
@@ -488,8 +488,16 @@ else
   # back to its flattened output so an UNKNOWN still carries its reason into the ledger.
   EXCL_SUM="$(printf '%s\n' "$EXCL_OUT" | grep '^EXCLUDED-DOMAINS:' | head -1 | sed 's/^EXCLUDED-DOMAINS:[[:space:]]*//' || true)"
   [ -n "$EXCL_SUM" ] || EXCL_SUM="$(printf '%s' "$EXCL_OUT" | tr '\n' ' ' | sed 's/[[:space:]]\{1,\}/ /g; s/^ *//; s/ *$//' | cap400)"
+  # An ADVISORY on exit 0 must survive INTO the verdict and the ledger row — the citation dial's
+  # whole bargain is "visible without deciding", and the first version of this branch swallowed it:
+  # the classifier printed ADVISORY-DOMAINS and the gate replaced it with a fixed all-clear line,
+  # so the one output the human actually reads lost the visibility the decision was made for.
+  # info(), not a veto — stated, never blocking. (Found by the adversarial re-review of the PR
+  # that introduced the dial.)
+  EXCL_ADV="$(printf '%s\n' "$EXCL_OUT" | grep '^ADVISORY-DOMAINS:' | head -1 | sed 's/^ADVISORY-DOMAINS:[[:space:]]*//' || true)"
   case "$EXCL_RC" in
-    0) ok "no excluded domain touched (guardrail floor, contract domain, destructive migration, erasure)" ;;
+    0) ok "no excluded domain touched (guardrail floor, contract domain, destructive migration, erasure)"
+       [ -z "$EXCL_ADV" ] || info "advisory (not gating, citation dial): $EXCL_ADV cited without declared paths — visible here so it reaches the ledger row" ;;
     1) no_go "touches an excluded domain — the human merges these, always: $EXCL_SUM" ;;
     *) unknown "the domain classifier could not verify this PR (fail closed): $EXCL_SUM" ;;
   esac

--- a/.claude/skills/wai-pr-review/scripts/merge-gate.sh
+++ b/.claude/skills/wai-pr-review/scripts/merge-gate.sh
@@ -176,6 +176,10 @@ A `MOOT` row is a review that ran AFTER the PR was merged — the gate could pre
 not a decision; leave its outcome blank and do not count it in fp/fn. Its value is the opposite of
 a missing row: it records that the gate *ran and was too late*, rather than reading as never-checked.
 
+**Rows belong on the default branch (#35).** The gate writes its row wherever it runs; a row left
+on a feature branch rides that branch's stale copy of this file, and a later squash-merge has
+deleted such rows twice. Collect loose rows into a small chore PR promptly.
+
 **Weekly:** read the GO rows you merged. Any you would now block → tag `fn`. Do not skip this; the
 `fn` count is the whole reason the ledger exists.
 
@@ -206,6 +210,18 @@ LEDGER_HDR
   # depend on that); only the cell got wider, and a cut is now marked as one.
   _lw=$(printf '%s\n' "$_srt" | tr '\n' ';' | sed 's/|/\//g; s/[[:space:]]\{1,\}/ /g; s/^[ ;]*//; s/[ ;]*$//' | cap400)
   printf '| %s | %s | %s | %s | |\n' "$(date -u +%Y-%m-%dT%H:%MZ 2>/dev/null || echo '?')" "$PR" "$1" "$_lw" >> "$_led" 2>/dev/null || true
+  # THE ROW BELONGS ON MAIN (#35, decided 2026-08-18). The ledger stays IN-REPO — numbers-lint
+  # re-measures the repo's published ledger claims in CI, and a ledger in ~/.claude would break
+  # that loop — but an append-only file written on whatever branch is checked out has LOST a row
+  # twice in squash races (#28, #31), and one field repo invented this rule by hand in its
+  # CLAUDE.md. So the script says it, every time it lands a row anywhere but the default branch:
+  # collect loose rows into a small chore PR promptly. Fail-open: no git answer, no note.
+  _cur="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  _def="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')" || true
+  [ -n "$_def" ] || _def=main
+  if [ -n "$_cur" ] && [ "$_cur" != "$_def" ]; then
+    echo "note: this ledger row landed on branch '$_cur' — ledger rows belong on $_def (#35). Collect loose rows into a small chore PR promptly: a stale branch copy has deleted rows in a squash race twice (#28, #31)."
+  fi
 }
 
 # emit_runlog LABEL — ONE attendance row beside the verdict (issue #11: the record measures side

--- a/.claude/skills/wai-pr-review/scripts/merge-gate.sh
+++ b/.claude/skills/wai-pr-review/scripts/merge-gate.sh
@@ -111,8 +111,8 @@ done
 # So the default base is the enclosing git worktree; an explicit argument or env override still
 # wins, and outside any repo the cwd stays the base (fixtures and bare dirs keep working).
 # Deliberately --show-toplevel, NOT the --git-common-dir parent: rows belong to the worktree that
-# produced them — consolidating across worktrees changes WHERE state lands, which is issue #35's
-# still-open human decision, not this fix's.
+# produced them — consolidating across worktrees changes WHERE state lands, which was the ledger-home
+# question's contested half (decided 2026-08-18: rows stay per-worktree, collected to main), not this fix's.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 CATALOG="${REPO_ROOT:-.}/docs/architecture/quality-attributes.md"
 
@@ -176,7 +176,7 @@ A `MOOT` row is a review that ran AFTER the PR was merged — the gate could pre
 not a decision; leave its outcome blank and do not count it in fp/fn. Its value is the opposite of
 a missing row: it records that the gate *ran and was too late*, rather than reading as never-checked.
 
-**Rows belong on the default branch (#35).** The gate writes its row wherever it runs; a row left
+**Rows belong on the default branch (ledger-home decision, 2026-08-18).** The gate writes its row wherever it runs; a row left
 on a feature branch rides that branch's stale copy of this file, and a later squash-merge has
 deleted such rows twice. Collect loose rows into a small chore PR promptly.
 
@@ -210,7 +210,7 @@ LEDGER_HDR
   # depend on that); only the cell got wider, and a cut is now marked as one.
   _lw=$(printf '%s\n' "$_srt" | tr '\n' ';' | sed 's/|/\//g; s/[[:space:]]\{1,\}/ /g; s/^[ ;]*//; s/[ ;]*$//' | cap400)
   printf '| %s | %s | %s | %s | |\n' "$(date -u +%Y-%m-%dT%H:%MZ 2>/dev/null || echo '?')" "$PR" "$1" "$_lw" >> "$_led" 2>/dev/null || true
-  # THE ROW BELONGS ON MAIN (#35, decided 2026-08-18). The ledger stays IN-REPO — numbers-lint
+  # THE ROW BELONGS ON MAIN (the ledger-home decision, 2026-08-18). The ledger stays IN-REPO — numbers-lint
   # re-measures the repo's published ledger claims in CI, and a ledger in ~/.claude would break
   # that loop — but an append-only file written on whatever branch is checked out has LOST a row
   # twice in squash races (#28, #31), and one field repo invented this rule by hand in its
@@ -220,7 +220,7 @@ LEDGER_HDR
   _def="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')" || true
   [ -n "$_def" ] || _def=main
   if [ -n "$_cur" ] && [ "$_cur" != "$_def" ]; then
-    echo "note: this ledger row landed on branch '$_cur' — ledger rows belong on $_def (#35). Collect loose rows into a small chore PR promptly: a stale branch copy has deleted rows in a squash race twice (#28, #31)."
+    echo "note: this ledger row landed on branch '$_cur' — ledger rows belong on $_def (ledger-home decision). Collect loose rows into a small chore PR promptly: a stale branch copy has deleted rows in a squash race twice (#28, #31)."
   fi
 }
 

--- a/.claude/skills/wai-retro/scripts/retro-compliance.sh
+++ b/.claude/skills/wai-retro/scripts/retro-compliance.sh
@@ -110,6 +110,40 @@ else
   echo "    per skill: $PERSKILL"
 fi
 
+# ── the invocation denominator (opt-in hook, #29) ────────────────────────────────────────────────
+# invocation-log.md is written MECHANICALLY by the PostToolUse hook a developer opted into; the run
+# log above is the model-written numerator. The difference is per-skill prompt-contract compliance
+# — the number this section existed to imply and could never state. ABSENCE of the file is a
+# legitimate state (the hook is opt-in), so it is a named line, never an exit 2: "not installed"
+# must never read as "nothing ran".
+ILOG="${INVOCATION_LOG:-docs/architecture/invocation-log.md}"
+if [ -f "$ILOG" ] && [ -r "$ILOG" ]; then
+  IVRAW="$(awk -F'|' -v since="$SINCE" '
+    function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+    /^\| *[0-9][0-9][0-9][0-9]-/ {
+      if (since != "" && substr(trim($2), 1, 10) < since) next
+      n++; sk[trim($3)]++
+    }
+    END { print n + 0; for (s in sk) print sk[s] " " s }' "$ILOG")"
+  IVN="$(printf '%s\n' "$IVRAW" | head -1)"
+  if [ "$IVN" = 0 ]; then
+    echo "  invocations (hook): none — 0 rows in the period ($ILOG)"
+  else
+    # Cross per skill: invoked N (mechanical) vs logged M (model). logged > invoked is possible —
+    # a run on a machine without the hook — and is printed as-is, never clamped: a number that
+    # cannot exceed its denominator is a number someone normalised.
+    IVCROSS="$(printf '%s\n' "$IVRAW" | sed 1d | sort -rn | while IFS=' ' read -r _n _sk; do
+                 [ -n "$_sk" ] || continue
+                 _m="$(printf '%s\n' "$RLRAW" | sed 1d | grep -E " $_sk\$" | awk '{print $1; exit}')"
+                 printf '%s invoked %s · logged %s\n' "$_sk" "$_n" "${_m:-0}"
+               done | awk '{ s = s (s ? "  |  " : "") $0 } END { print s }')"
+    echo "  invocations (hook): $IVN in the period ($ILOG)"
+    echo "    compliance: $IVCROSS"
+  fi
+else
+  echo "  invocations (hook): not installed — the denominator is opt-in (sh .claude/skills/wai/scripts/invocation-log.sh --snippet); absence means the hook is off, never that nothing ran"
+fi
+
 # ── gate-ledger verdicts in the period ───────────────────────────────────────────────────────────
 # Same row anchor as gate-stats.sh — one parser convention for the ledger, everywhere. This block
 # counts rows and collects PR numbers; every RATE about the ledger belongs to gate-stats.sh.

--- a/.claude/skills/wai/SKILL.md
+++ b/.claude/skills/wai/SKILL.md
@@ -128,6 +128,15 @@ PERIODIC (after a few features/refactors, or on security triggers)
   at all, so read nothing as clean. Both at once exits 1, and both summary lines print. It reports
   presence now; staleness of an already-generated artifact (an old `ci.yml`) still needs a
   `wai-cicd` re-run.
+- **Want the run log's missing denominator — how often skills actually START, not just hand back?**
+  → opt in, per developer, to the invocation hook: `sh scripts/invocation-log.sh --snippet` prints
+  the `PostToolUse` block for your **`.claude/settings.local.json`** (never `settings.json` — a
+  committed hook would switch it on repo-wide; personal state never becomes repo state). The hook
+  appends one mechanical row per wai-skill invocation to `docs/architecture/invocation-log.md` —
+  no outcome column, ever; the model-written numerator stays `run-log.md`, and
+  `retro-compliance.sh` reports the difference as per-skill compliance. Fail-open by design:
+  `exit 0` = row appended or input ignored (a hook must never break the harness) · `exit 2` =
+  misuse only (an unknown argument), so a typo in the hook config is visible.
 - **Did a script and the prompt that invokes it drift apart** — after changing a script's exit
   codes, renaming a skill, or before a release? → run
   `sh scripts/contract-lint.sh` (from this skill's directory). It reads both sides of the joint and fails

--- a/.claude/skills/wai/references/agent-git-protocol.md
+++ b/.claude/skills/wai/references/agent-git-protocol.md
@@ -180,7 +180,7 @@ matched as such, and erasure granularity comes from `ERASURE_PATHS` and the grep
 Labels and family prefixes may only **ADD** a domain, never subtract one — a missing or renamed
 label can never *suppress* a path or diff match.
 
-**The citation dial (#30, decided 2026-08-18).** A citation or label *decides* the verdict only
+**The citation dial (the citation-dial decision, 2026-08-18 — issue #30).** A citation or label *decides* the verdict only
 where its family is **anchored** — the repo declares paths whose shape classifies into it
 (`EX-GDPR` anchors on a non-empty `ERASURE_PATHS`). Unanchored, the citation is **reported as
 advisory** (`ADVISORY-DOMAINS:` in the classifier's output) but does not gate: where a repo

--- a/.claude/skills/wai/references/agent-git-protocol.md
+++ b/.claude/skills/wai/references/agent-git-protocol.md
@@ -180,6 +180,16 @@ matched as such, and erasure granularity comes from `ERASURE_PATHS` and the grep
 Labels and family prefixes may only **ADD** a domain, never subtract one — a missing or renamed
 label can never *suppress* a path or diff match.
 
+**The citation dial (#30, decided 2026-08-18).** A citation or label *decides* the verdict only
+where its family is **anchored** — the repo declares paths whose shape classifies into it
+(`EX-GDPR` anchors on a non-empty `ERASURE_PATHS`). Unanchored, the citation is **reported as
+advisory** (`ADVISORY-DOMAINS:` in the classifier's output) but does not gate: where a repo
+declares no surface for a family, a citation is documentation, not contact. The rule exists
+because the safe version was measured expensive — the false alarm stood alone three times in one
+field repo, and the cheapest route to a green gate became *not citing catalog IDs*, the exact
+opposite of what the suite instructs. Paths and diff statements stay authoritative everywhere,
+and under `--autonomy` an advisory citation still **holds** the drain — autonomy errs closed.
+
 **Enforcement — stated once, two modes:**
 
 - **Everyday mode.** A touched excluded domain ⇒ `merge-gate.sh` returns **NO-GO** ⇒ **the human

--- a/.claude/skills/wai/scripts/excluded-domains.sh
+++ b/.claude/skills/wai/scripts/excluded-domains.sh
@@ -284,7 +284,44 @@ acquire_inputs() {
 # =================================================================================================
 TAGS=""
 DETAIL=""
+ADVISORY=""
 add_tag()    { TAGS="$TAGS $1"; }
+add_advisory() { ADVISORY="$ADVISORY $1"; }
+
+# Is a family ANCHORED — does this repo declare paths that belong to it? (#30, decided 2026-08-18.)
+# EX-GDPR anchors on a non-empty ERASURE_PATHS. EX-PAY/AUTH/API/SEC anchor on a CONTRACT_PATHS glob
+# whose SHAPE classifies into that family (the same contract_subtags read used for tagging); a glob
+# whose shape is indeterminate (EX-CONTRACT) anchors nothing — the paths themselves stay fully
+# protected by the path check regardless, this only scopes the advisory citation channel.
+#
+# WHY: the widening rule ("a citation may only widen") was safe and it was measured expensive — in
+# a repo declaring no paths for a family, the false alarm stood ALONE three times, and the cheapest
+# route to a green gate became "don't cite catalog IDs": the exact opposite of what the suite asks
+# for. Where a family has no declared surface, a citation is documentation, not contact — it is
+# still REPORTED (an advisory line, visible in the verdict) but no longer DECIDES. Where the family
+# IS anchored, nothing changes. Paths and diff statements remain authoritative everywhere; under
+# --autonomy the advisory set still HOLDS the drain (autonomy errs closed, always).
+ANCHORED=""
+compute_anchored() {
+  _cp="$(conf_val CONTRACT_PATHS "$MERGE_CONF")"
+  _ep="$(conf_val ERASURE_PATHS  "$MERGE_CONF")"
+  [ -n "$_ep" ] && ANCHORED="$ANCHORED EX-GDPR"
+  if [ -n "$_cp" ]; then
+    _fams="$(printf '%s\n' "$_cp" | tr -s ' \t' '\n' | while IFS= read -r _g; do
+               [ -n "$_g" ] || continue; contract_subtags "$_g"
+             done | sort -u | tr '\n' ' ')"
+    case "$_fams" in *EX-PAY*)  ANCHORED="$ANCHORED EX-PAY"  ;; esac
+    case "$_fams" in *EX-AUTH*) ANCHORED="$ANCHORED EX-AUTH" ;; esac
+    case "$_fams" in *EX-API*)  ANCHORED="$ANCHORED EX-API"  ;; esac
+    case "$_fams" in *EX-SEC*)  ANCHORED="$ANCHORED EX-SEC"  ;; esac
+  fi
+}
+anchored() { case " $ANCHORED " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+# Widen into the deciding set only where anchored; elsewhere the citation stays visible as advisory.
+widen() {   # $1 = tag, $2 = detail
+  if anchored "$1"; then add_tag "$1"; add_detail "$2"
+  else add_advisory "$1"; add_detail "advisory only ($1 not anchored — no declared paths for this family): $2"; fi
+}
 add_detail() { DETAIL="$DETAIL  x $1
 "; }
 
@@ -355,25 +392,33 @@ classify() {
   [ -n "$META_FILE" ] && [ -f "$META_FILE" ] && cat "$META_FILE" >> "$_scan" 2>/dev/null
   PREFIXES="$(grep -oiE '(PAY|AUTH|API|SEC|GDPR)-[0-9]+' "$_scan" 2>/dev/null \
               | sed 's/-[0-9].*//' | tr '[:lower:]' '[:upper:]' | sort -u)"
+  compute_anchored
   for _pf in $PREFIXES; do
     case "$_pf" in
-      PAY)  add_tag EX-PAY;  add_detail "widened by a cited PAY- family id (family only, number not resolved)" ;;
-      AUTH) add_tag EX-AUTH; add_detail "widened by a cited AUTH- family id (family only)" ;;
-      API)  add_tag EX-API;  add_detail "widened by a cited API- family id (family only)" ;;
-      SEC)  add_tag EX-SEC;  add_detail "widened by a cited SEC- family id (family only)" ;;
-      GDPR) add_tag EX-GDPR; add_detail "widened by a cited GDPR- family id (family only)" ;;
+      PAY)  widen EX-PAY  "widened by a cited PAY- family id (family only, number not resolved)" ;;
+      AUTH) widen EX-AUTH "widened by a cited AUTH- family id (family only)" ;;
+      API)  widen EX-API  "widened by a cited API- family id (family only)" ;;
+      SEC)  widen EX-SEC  "widened by a cited SEC- family id (family only)" ;;
+      GDPR) widen EX-GDPR "widened by a cited GDPR- family id (family only)" ;;
     esac
   done
   if [ -n "$META_FILE" ] && [ -f "$META_FILE" ]; then
     LB="$(tr '[:upper:]' '[:lower:]' < "$META_FILE" 2>/dev/null)"
-    case "$LB" in *billing*|*payment*|*token*) add_tag EX-PAY;  add_detail "widened by a payment/billing label" ;; esac
-    case "$LB" in *auth*|*login*|*'user management'*) add_tag EX-AUTH; add_detail "widened by an auth/user label" ;; esac
-    case "$LB" in *gdpr*|*erasure*|*deletion*|*'right to be forgotten'*) add_tag EX-GDPR; add_detail "widened by a gdpr/erasure label" ;; esac
+    case "$LB" in *billing*|*payment*|*token*) widen EX-PAY  "widened by a payment/billing label" ;; esac
+    case "$LB" in *auth*|*login*|*'user management'*) widen EX-AUTH "widened by an auth/user label" ;; esac
+    case "$LB" in *gdpr*|*erasure*|*deletion*|*'right to be forgotten'*) widen EX-GDPR "widened by a gdpr/erasure label" ;; esac
   fi
 
-  # Dedupe.
+  # Dedupe — and an advisory tag that is ALSO a real tag collapses into the real one.
   # shellcheck disable=SC2086  # TAGS must word-split
   TAGS="$(printf '%s\n' $TAGS | grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/  */ /g; s/^ //; s/ $//')"
+  # grep, NOT `case … esac` — a case inside $( ) is a syntax error in bash 3.2, which is what
+  # /bin/sh IS on macOS. shellcheck passes it; the shell does not. This suite has now relearned
+  # that FIVE times (merge-gate.sh's comment counted four), and this line was the fifth.
+  # shellcheck disable=SC2086
+  ADVISORY="$(printf '%s\n' $ADVISORY | grep -v '^$' | sort -u | while IFS= read -r _a; do
+                printf '%s\n' "$TAGS" | tr ' ' '\n' | grep -qxF "$_a" || printf '%s ' "$_a"
+              done | sed 's/ $//')"
 }
 
 # =================================================================================================
@@ -424,7 +469,14 @@ if [ "$AUTONOMY" -eq 1 ]; then
     echo "VERDICT: UNKNOWN — AUTONOMY_AFFIRMED is absent; no human affirmed this surface. Held."; exit 2
   fi
 
-  # Defense-in-depth: the blocklist must be CLEAR.
+  # Defense-in-depth: the blocklist must be CLEAR — including the ADVISORY set. The everyday gate
+  # lets an unanchored citation report without deciding; the unattended drain does not get that
+  # nuance. Autonomy errs closed, always.
+  if [ -n "$ADVISORY" ]; then
+    printf '%s' "$DETAIL"
+    echo "VERDICT: HELD — advisory domain citation(s) ($ADVISORY) are not clear enough for an unattended merge; held for the human."
+    exit 1
+  fi
   if [ -n "$TAGS" ]; then
     printf '%s' "$DETAIL"
     echo "EXCLUDED-DOMAINS: $TAGS"
@@ -447,7 +499,13 @@ fi
 
 # --- Default mode -------------------------------------------------------------------------------
 if [ -z "$TAGS" ]; then
-  echo "VERDICT: CLEAR — no excluded domain touched."
+  if [ -n "$ADVISORY" ]; then
+    printf '%s' "$DETAIL"
+    echo "ADVISORY-DOMAINS: $ADVISORY"
+    echo "VERDICT: CLEAR — no excluded domain touched (advisory citations reported above; not gating, per #30)."
+  else
+    echo "VERDICT: CLEAR — no excluded domain touched."
+  fi
   exit 0
 else
   printf '%s' "$DETAIL"

--- a/.claude/skills/wai/scripts/invocation-log.sh
+++ b/.claude/skills/wai/scripts/invocation-log.sh
@@ -60,6 +60,12 @@ fi
 IN="$(head -c 65536 2>/dev/null || true)"
 printf '%s' "$IN" | grep -q '"tool_name"[[:space:]]*:[[:space:]]*"Skill"' || exit 0
 SKILL="$(printf '%s' "$IN" | grep -o '"skill"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"skill"[[:space:]]*:[[:space:]]*"//; s/"$//')"
+# Table-safe, like run-log.sh's cell(): the name is the ONE field this row takes from the payload,
+# and a name carrying '|' forged extra columns — a crafted skill name minted rows with a fake
+# timestamp and skill, corrupting the very denominator this log exists to make trustworthy.
+# Pipes become '/', whitespace collapses, 80 chars on a word boundary with a visible cut.
+SKILL="$(printf '%s' "$SKILL" | tr '\n' ' ' | sed 's/|/\//g; s/[[:space:]]\{1,\}/ /g; s/^ *//; s/ *$//' \
+  | awk '{ if (length($0) <= 80) print; else { s = substr($0, 1, 80); sub(/ [^ ]*$/, "", s); print s "…" } }')"
 case "$SKILL" in
   wai|wai-*) : ;;                       # only the suite's own skills — a foreign skill is not our denominator
   *) exit 0 ;;

--- a/.claude/skills/wai/scripts/invocation-log.sh
+++ b/.claude/skills/wai/scripts/invocation-log.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env sh
+# invocation-log.sh — the mechanical DENOMINATOR of skill runs (#29, decided 2026-08-18).
+#
+# The run log's two tiers were measured in the field: the script-written tier logged 9 of 9; every
+# prompt-written tier had gaps (architecture-audit 0 rows with a committed report, learning-gap 0
+# with a ledger entry, implementation 4 of 5). Self-logging that depends on the model is not a
+# measurement. The fix is two artifacts, NEVER merged:
+#
+#   invocations (THIS file's output)  — every wai-* skill invocation, written MECHANICALLY by a
+#                                        harness hook. No outcome column, ever: it counts starts,
+#                                        it judges nothing.
+#   run-log.md (run-log.sh)           — the model-written numerator, at hand-back, with outcome.
+#
+# The difference between the two is per-skill prompt-contract compliance, and retro-compliance.sh
+# reports it. A merged artifact would be worse than either: a row without an outcome is not a
+# subset of the run log, it is a forgery of one.
+#
+# OPT-IN, PER DEVELOPER (the learning-gap precedent): this script only runs if YOU wire it as a
+# Claude Code PostToolUse hook in your **.claude/settings.local.json** — never settings.json,
+# which would switch it on for every colleague (git protocol: personal state never becomes repo
+# state; the hook is personal, the LOG it appends is repo evidence like the gate ledger).
+# Print the exact snippet:   sh invocation-log.sh --snippet
+#
+# FAIL-OPEN, ABSOLUTELY: a hook that breaks the harness is worse than a lost row. Bad JSON, no
+# repo, unwritable file — everything exits 0 silently. The ONE defined negative is misuse
+# (an unknown argument): exit 2, so a typo in the hook config is visible, not swallowed.
+#
+#   exit 0  row appended, or input ignored (non-Skill tool, non-wai skill, unreadable anything)
+#   exit 2  misuse: an unknown argument
+#
+# Usage: sh invocation-log.sh            (hook mode: reads the PostToolUse JSON from stdin)
+#        sh invocation-log.sh --snippet  (print the settings.local.json opt-in snippet)
+#        $INVOCATION_LOG overrides the output path (the $RUN_LOG pattern).
+
+set -u
+if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi
+
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    --snippet)
+      cat <<'SNIP'
+Add to .claude/settings.local.json (per-developer opt-in — NOT settings.json):
+{
+  "hooks": {
+    "PostToolUse": [
+      { "matcher": "Skill",
+        "hooks": [ { "type": "command",
+                     "command": "sh .claude/skills/wai/scripts/invocation-log.sh" } ] }
+    ]
+  }
+}
+SNIP
+      exit 0 ;;
+    *) echo "invocation-log: unknown argument '$1' (hook mode reads stdin; --snippet prints the opt-in)" >&2; exit 2 ;;
+  esac
+fi
+
+# Hook mode. Read stdin (bounded), extract tool_name + skill. No jq — POSIX text tools only, and
+# every failure path is a silent exit 0 (fail-open: never break the harness over a log row).
+IN="$(head -c 65536 2>/dev/null || true)"
+printf '%s' "$IN" | grep -q '"tool_name"[[:space:]]*:[[:space:]]*"Skill"' || exit 0
+SKILL="$(printf '%s' "$IN" | grep -o '"skill"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"skill"[[:space:]]*:[[:space:]]*"//; s/"$//')"
+case "$SKILL" in
+  wai|wai-*) : ;;                       # only the suite's own skills — a foreign skill is not our denominator
+  *) exit 0 ;;
+esac
+
+# Default path is REPO-relative, not cwd-relative (merge-gate.sh carries the incident; same rule).
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+LOG="${INVOCATION_LOG:-${REPO_ROOT:-.}/docs/architecture/invocation-log.md}"
+
+if [ ! -f "$LOG" ]; then
+  mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
+  cat > "$LOG" 2>/dev/null <<'HDR' || true
+# Invocation log
+
+Every row is a wai-* skill INVOCATION, appended mechanically by a harness hook the developer
+opted into (`invocation-log.sh --snippet`). This is the **denominator**: it counts starts and
+judges nothing — there is deliberately **no outcome column**, and there never will be. The
+model-written numerator with outcomes is `run-log.md`; the difference between the two files is
+per-skill prompt-contract compliance (`retro-compliance.sh` reports it). **Never merge the two:**
+a row without an outcome is not a subset of the run log, it is a forgery of one.
+
+**APPEND-ONLY**, like the ledger and the run log. A gap here means the hook was not installed
+(opt-in, per developer) — it never means "nothing ran".
+
+| when (UTC) | skill |
+|---|---|
+HDR
+fi
+
+printf '| %s | %s |\n' "$(date -u +%Y-%m-%dT%H:%MZ 2>/dev/null || echo '?')" "$SKILL" >> "$LOG" 2>/dev/null || true
+exit 0

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ model cooperating:
 |---|---|---|
 | **Server-side** | branch protection on `main`, required checks, CODEOWNERS | No — the model does not run there |
 | **Local hooks** | [`pre-commit`](.githooks/pre-commit) (no commits on the default branch), [`pre-push`](.githooks/pre-push) (no pushes to a branch whose PR is merged) — **wire them once: `git config core.hooksPath .githooks`** | Only visibly, via `--no-verify` |
-| **Scripts a skill invokes** | `merge-gate.sh`, `catalog-lint.sh`, the audit and protocol lints — 27 scripts across the suite | In principle yes — which is why this was **measured**, not assumed ([Test 0](docs/empirics.md)) |
+| **Scripts a skill invokes** | `merge-gate.sh`, `catalog-lint.sh`, the audit and protocol lints — 28 scripts across the suite | In principle yes — which is why this was **measured**, not assumed ([Test 0](docs/empirics.md)) |
 
 The merge policy itself is **policy-as-code**: the guardrail floor is hardcoded in the scripts,
 the repo-specific half lives in `docs/architecture/merge-gate.conf` — and config can only ever
@@ -103,7 +103,7 @@ claim beyond software is a position, not a measurement: supervised, well-tooled 
 
 **The price, honestly:** the deterministic layer took nine repair commits in two days; the gate
 once failed *open* under zsh and later could never say GO at all. That is why
-[`tests/`](tests/) exists — 347 cases, **founded** on bugs that shipped and grown into the
+[`tests/`](tests/) exists — 370 cases, **founded** on bugs that shipped and grown into the
 regression guards around them, run on two shells because shellcheck passed a construct that is a
 syntax error in the `/bin/sh` of macOS. (The second shell runs locally on every branch, not in
 CI: macOS runners bill at 10× and exhausted the private repo's Actions minutes until no check
@@ -415,7 +415,7 @@ install.sh                                       # idempotent installer (inject/
   wai-retro/                                     # artifact-derived retrospectives + retro-compliance.sh
   wai-learning-gap/                              # personal, opt-in; own scripts + tests
 .githooks/                                       # pre-commit (no default-branch commits), pre-push (no dead-branch pushes)
-tests/                                           # 347 cases for the deciding scripts — founded on bugs that shipped
+tests/                                           # 370 cases for the deciding scripts — founded on bugs that shipped
 docs/                                        # history, empirics, field reports, ADRs, audits, catalog, open questions
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ claim beyond software is a position, not a measurement: supervised, well-tooled 
 
 **The price, honestly:** the deterministic layer took nine repair commits in two days; the gate
 once failed *open* under zsh and later could never say GO at all. That is why
-[`tests/`](tests/) exists — 370 cases, **founded** on bugs that shipped and grown into the
+[`tests/`](tests/) exists — 373 cases, **founded** on bugs that shipped and grown into the
 regression guards around them, run on two shells because shellcheck passed a construct that is a
 syntax error in the `/bin/sh` of macOS. (The second shell runs locally on every branch, not in
 CI: macOS runners bill at 10× and exhausted the private repo's Actions minutes until no check
@@ -415,7 +415,7 @@ install.sh                                       # idempotent installer (inject/
   wai-retro/                                     # artifact-derived retrospectives + retro-compliance.sh
   wai-learning-gap/                              # personal, opt-in; own scripts + tests
 .githooks/                                       # pre-commit (no default-branch commits), pre-push (no dead-branch pushes)
-tests/                                           # 370 cases for the deciding scripts — founded on bugs that shipped
+tests/                                           # 373 cases for the deciding scripts — founded on bugs that shipped
 docs/                                        # history, empirics, field reports, ADRs, audits, catalog, open questions
 ```
 

--- a/docs/architecture/run-log.md
+++ b/docs/architecture/run-log.md
@@ -30,3 +30,4 @@ a suite update must never touch this file (the same never-eaten guarantee as the
 | 2026-08-18T19:43Z | wai-implementation | ledger landing chore | 4 rows landed, 3 tags, marker planted |
 | 2026-08-18T19:50Z | wai-implementation | #35 ledger home codified | in-repo + row-belongs-on-main note; 2 cases |
 | 2026-08-18T19:55Z | wai-implementation | #30 citation dial (option b) | anchored-family advisory channel; 8 cases |
+| 2026-08-18T19:57Z | wai-implementation | #29 pt.2 invocation denominator | hook script + retro crossing; 11 cases |

--- a/docs/architecture/run-log.md
+++ b/docs/architecture/run-log.md
@@ -31,3 +31,4 @@ a suite update must never touch this file (the same never-eaten guarantee as the
 | 2026-08-18T19:50Z | wai-implementation | #35 ledger home codified | in-repo + row-belongs-on-main note; 2 cases |
 | 2026-08-18T19:55Z | wai-implementation | #30 citation dial (option b) | anchored-family advisory channel; 8 cases |
 | 2026-08-18T19:57Z | wai-implementation | #29 pt.2 invocation denominator | hook script + retro crossing; 11 cases |
+| 2026-08-18T20:01Z | wai-implementation | installer no-op answer (D) | diff -rq over owned set; 2 cases |

--- a/docs/architecture/run-log.md
+++ b/docs/architecture/run-log.md
@@ -28,3 +28,4 @@ a suite update must never touch this file (the same never-eaten guarantee as the
 | 2026-08-18T17:23Z | wai-pr-review | PR #33 | MOOT |
 | 2026-08-18T19:13Z | wai-pr-review | PR #34 | NO-GO |
 | 2026-08-18T19:43Z | wai-implementation | ledger landing chore | 4 rows landed, 3 tags, marker planted |
+| 2026-08-18T19:50Z | wai-implementation | #35 ledger home codified | in-repo + row-belongs-on-main note; 2 cases |

--- a/docs/architecture/run-log.md
+++ b/docs/architecture/run-log.md
@@ -29,3 +29,4 @@ a suite update must never touch this file (the same never-eaten guarantee as the
 | 2026-08-18T19:13Z | wai-pr-review | PR #34 | NO-GO |
 | 2026-08-18T19:43Z | wai-implementation | ledger landing chore | 4 rows landed, 3 tags, marker planted |
 | 2026-08-18T19:50Z | wai-implementation | #35 ledger home codified | in-repo + row-belongs-on-main note; 2 cases |
+| 2026-08-18T19:55Z | wai-implementation | #30 citation dial (option b) | anchored-family advisory channel; 8 cases |

--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,36 @@ fi
 # tests/run.sh holds this as a test: an update into a repo with a populated ledger and run log
 # must leave both byte-identical. Whoever teaches this script to "clean up" docs/ goes red there.
 
+# 3b. THE NO-OP ANSWER (field-reported, 2026-08-17): "does this update change anything for me?"
+# A field repo computed this by hand — hashed its installed tree against the suite's — and got it
+# subtly wrong: the hash covered ALL of .claude/skills, including the repo's own skills the
+# installer never touches, so the number compared against nothing upstream. The honest comparison
+# is exactly the set this script owns: the manifest's skills, content vs the source. When they are
+# byte-identical the install still proceeds (the stamp advances — doctor's staleness checks want
+# the newest commit), but the run SAYS the truth: zero behavioral change. A version stamp that
+# advances silently over zero delta reads as "something happened", and the next audit inherits
+# that misread.
+if [ -n "$OWNED" ]; then
+  NOOP=yes
+  for s in $NEW_SET; do
+    if ! printf '%s
+' "$OWNED" | grep -qx "$s"; then NOOP=no; break; fi     # a new skill = change
+    if [ ! -d "$SKILLS_DIR/$s" ] || ! diff -rq "$SRC/$s" "$SKILLS_DIR/$s" >/dev/null 2>&1; then
+      NOOP=no; break
+    fi
+  done
+  # a skill we own that upstream dropped is also a change (it is about to be pruned)
+  if [ "$NOOP" = yes ]; then
+    for old in $OWNED; do
+      printf '%s
+' "$NEW_SET" | grep -qx "$old" || { NOOP=no; break; }
+    done
+  fi
+  if [ "$NOOP" = yes ]; then
+    echo "no behavioral change: the installed suite skills are byte-identical to this source — only the version stamp advances."
+  fi
+fi
+
 # 4. Prune skills WE installed that no longer exist upstream (renamed or removed).
 for old in $OWNED; do
   if ! printf '%s\n' "$NEW_SET" | grep -qx "$old"; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -894,6 +894,17 @@ edfix; printf '+SEC-7 unchanged\n' > "$ED_D/diff"; printf 'src/util/format.ts\n'
 out="$(edrun --autonomy)"; rc=$?
 assert "--autonomy: an advisory citation is HELD, not waved through (autonomy errs closed)" 1 "$rc" "$out" 'HELD — advisory domain citation'
 
+# THE ADVISORY SURVIVES THE GATE. The dial's bargain is "visible without deciding"; the gate's
+# exit-0 branch initially swallowed the classifier's ADVISORY-DOMAINS line, so the one output the
+# human reads (verdict + ledger row) lost the visibility the decision was made for. info, not veto.
+gfix; printf 'benw\n' > "$D/login" 2>/dev/null || true
+printf '+| SEC-7 | unchanged |\n' > "$D/diff"
+out="$(gate)"; rc=$?
+assert "gate on a CLEAR-with-advisory diff → GO, and the advisory rides the verdict output" 0 "$rc" "$out" 'advisory \(not gating, citation dial\): EX-SEC'
+if grep -q 'advisory (not gating, citation dial): EX-SEC' "$D/docs/architecture/gate-ledger.md" 2>/dev/null; then
+  ok "  · and the ledger row carries it (visible where the tags are audited)"
+else bad "  · and the ledger row carries it" "$(tail -1 "$D/docs/architecture/gate-ledger.md" 2>&1)"; fi
+
 # An input that cannot be read is HELD, never CLEAR — the fail-closed rule the whole suite rests on.
 edfix; out="$(EXCLUDED_DOMAINS_MERGE_CONF="$ED_D/merge-gate.conf" EXCLUDED_DOMAINS_COORD_CONF="$ED_D/coordination.conf" sh "$ED" --files "$ED_D/files" --diff "$ED_D/does-not-exist" 2>&1)"; rc=$?
 assert "an unreadable diff → UNKNOWN, exit 2 (fail-closed, never CLEAR)" 2 "$rc" "$out" 'UNKNOWN' 'VERDICT: CLEAR'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -233,6 +233,21 @@ else bad "  · and NOTHING was planted inside .claude/skills/" "stray tree: $D/.
 # Outside any git repo the cwd stays the base — every other fixture in this file IS that case
 # (gfix dirs are plain directories), so the fallback is pinned by the whole suite around this.
 
+# ROWS BELONG ON MAIN (#35, decided 2026-08-18). The gate writes its row wherever it runs; that
+# row has been squash-deleted twice (#28, #31) when it rode a feature branch's stale ledger copy.
+# The decision: the ledger stays in-repo (numbers-lint re-measures its claims in CI), and the
+# script SAYS where the row belongs every time it lands one off the default branch.
+gfix
+( cd "$D" && git init -q -b main . && git checkout -q -b feature-x ) 2>/dev/null
+out="$(gate)"; rc=$?
+assert "a gate run on a feature branch → verdict unchanged, and the row-belongs-on-main note prints" 0 "$rc" "$out" "landed on branch 'feature-x' — ledger rows belong on main"
+gfix
+( cd "$D" && git init -q -b main . ) 2>/dev/null
+out="$(gate)"; rc=$?
+assert "  · on the default branch itself, no note — a warning on every run is one nobody reads" 0 "$rc" "$out" 'VERDICT: GO' 'ledger rows belong on'
+# Outside a git repo (every other fixture here) there is no branch to name — the note stays off;
+# those fixtures all assert exact verdict output and double as the pin.
+
 # Post-merge = MOOT. A gate run on an already-merged PR must say so, not fake a GO/NO-GO — no
 # artefact watches ordering, and this is the one place the gate can. It must short-circuit BEFORE
 # the guardrail/contract checks (which are irrelevant once merged) and record a MOOT row, so an

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -662,6 +662,19 @@ assert "install.sh stamps the suite version and runs doctor" 0 "$rc" "$out" 'doc
 if [ -f "$IDIR/.claude/.wai-suite-version" ]; then ok "install.sh writes .wai-suite-version (Phase B foundation)"
 else bad "install.sh writes .wai-suite-version" "no version file at $IDIR/.claude/"; fi
 
+# THE NO-OP ANSWER (field-reported: a repo hand-hashed its tree to ask "does this update change
+# anything?" and got the scope wrong — its hash included its OWN skills, comparing against nothing).
+# The installer now answers it itself, over exactly the set it owns. Re-install into the SAME
+# target from the SAME source → byte-identical suite skills → the line prints; touch one owned
+# skill → it must NOT print (a no-op claim over a real delta would be the worse bug).
+out="$(sh "$ROOT/install.sh" "$IDIR" 2>&1)"; rc=$?
+assert "a second install from the same source says so: no behavioral change, stamp-only" 0 "$rc" "$out" 'no behavioral change: the installed suite skills are byte-identical'
+printf 'locally modified\n' >> "$IDIR/.claude/skills/wai/SKILL.md"
+out="$(sh "$ROOT/install.sh" "$IDIR" 2>&1)"; rc=$?
+assert "  · a modified owned skill → the no-op line must NOT print (delta is restored + reported)" 0 "$rc" "$out" 'installed: wai' 'no behavioral change'
+# A first install (no manifest) never claims no-op — ownership, not name-guessing, scopes the check;
+# the first IDIR install above is that case and printed no such line (asserted by its own matcher).
+
 # install.sh × the platform→wai rename.
 #
 # Every repo that already runs this suite carries a `.platform-suite-manifest`. If the installer

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -836,6 +836,51 @@ printf '+// refactor: rename an internal helper, no behaviour change\n' > "$ED_D
 out="$(edrun)"; rc=$?
 assert "a missing/renamed label cannot SUPPRESS a path match (advisory widens only)" 1 "$rc" "$out" 'EXCLUDED-DOMAINS:.*EX-PAY'
 
+# ── THE CITATION DIAL (#30, decided 2026-08-18: option b) ───────────────────────────────────────
+# The widening rule was safe and measurably expensive: in a repo declaring no paths for a family,
+# the citation false alarm stood ALONE three times, and the cheapest route to a green gate became
+# "don't cite catalog IDs" — the exact opposite of what the suite instructs. The dial: a citation
+# DECIDES only where the family is ANCHORED (declared paths whose shape classifies into it;
+# EX-GDPR anchors on ERASURE_PATHS). Unanchored, it is REPORTED as advisory — visible, not gating.
+# Paths and diff statements stay authoritative everywhere; --autonomy still holds on advisory.
+
+# Field case 1 (PR #186 class): an author's own self-review line "SEC-7: unchanged" — the fixture
+# conf declares billing/auth/erasure paths but nothing SEC-shaped, so EX-SEC is unanchored.
+edfix; printf '+| SEC-7 | unchanged - the server still checks for itself |\n' > "$ED_D/diff"
+out="$(edrun)"; rc=$?
+assert "an unanchored SEC citation → CLEAR with an ADVISORY line, not a NO-GO (field case, 3x alone)" 0 "$rc" "$out" 'ADVISORY-DOMAINS: EX-SEC' 'VERDICT: EXCLUDED'
+assert "  · and the advisory is VISIBLE, never silently dropped" 0 "$rc" "$out" 'advisory only \(EX-SEC not anchored'
+
+# The same citation with a security-shaped glob declared → anchored → decides, exactly as before.
+edfix; printf 'CONTRACT_PATHS="src/security/* src/billing/*"\nMIGRATION_PATHS="migrations/*"\nERASURE_PATHS="apps/api/src/erasure/*"\n' > "$ED_D/merge-gate.conf"
+printf '+| SEC-7 | unchanged |\n' > "$ED_D/diff"
+out="$(edrun)"; rc=$?
+assert "the SAME citation with a security-shaped glob declared → anchored, still EXCLUDED" 1 "$rc" "$out" 'EXCLUDED-DOMAINS:.*EX-SEC'
+
+# Field case 2 (PR #191 class): GDPR prose in a docs diff, with NO erasure surface declared.
+edfix; printf 'CONTRACT_PATHS="src/billing/*"\nMIGRATION_PATHS="migrations/*"\n' > "$ED_D/merge-gate.conf"
+printf '+since #119 there is a delete path (GDPR-3)\n' > "$ED_D/diff"
+out="$(edrun)"; rc=$?
+assert "a GDPR citation with no ERASURE_PATHS declared → advisory, not gating (docs-addendum case)" 0 "$rc" "$out" 'ADVISORY-DOMAINS: EX-GDPR' 'VERDICT: EXCLUDED'
+
+# Mixed: an anchored PAY citation decides while the unanchored SEC one reports — no cross-talk.
+edfix; printf '+PAY-2 applies here\n+SEC-7 unchanged\n' > "$ED_D/diff"
+out="$(edrun)"; rc=$?
+assert "anchored PAY decides, unanchored SEC reports — one verdict, both visible" 1 "$rc" "$out" 'EXCLUDED-DOMAINS:.*EX-PAY'
+assert "  · the advisory tag never leaks into the deciding EXCLUDED-DOMAINS line" 1 "$rc" "$out" 'advisory only \(EX-SEC' 'EXCLUDED-DOMAINS:.*EX-SEC'
+
+# A real erasure STATEMENT is diff-authoritative and is NOT downgraded by the dial — the dial
+# scopes the CITATION channel only. (The self-merge hole stays closed with no erasure conf at all.)
+edfix; printf 'CONTRACT_PATHS="src/billing/*"\nMIGRATION_PATHS="migrations/*"\n' > "$ED_D/merge-gate.conf"
+printf '+  DELETE FROM users WHERE id = $1\n' > "$ED_D/diff"
+out="$(edrun)"; rc=$?
+assert "a real DELETE FROM users stays EXCLUDED with no erasure conf — statements are authoritative" 1 "$rc" "$out" 'EXCLUDED-DOMAINS:.*EX-GDPR'
+
+# Under --autonomy the nuance disappears: an advisory citation HOLDS the unattended drain.
+edfix; printf '+SEC-7 unchanged\n' > "$ED_D/diff"; printf 'src/util/format.ts\n' > "$ED_D/files"
+out="$(edrun --autonomy)"; rc=$?
+assert "--autonomy: an advisory citation is HELD, not waved through (autonomy errs closed)" 1 "$rc" "$out" 'HELD — advisory domain citation'
+
 # An input that cannot be read is HELD, never CLEAR — the fail-closed rule the whole suite rests on.
 edfix; out="$(EXCLUDED_DOMAINS_MERGE_CONF="$ED_D/merge-gate.conf" EXCLUDED_DOMAINS_COORD_CONF="$ED_D/coordination.conf" sh "$ED" --files "$ED_D/files" --diff "$ED_D/does-not-exist" 2>&1)"; rc=$?
 assert "an unreadable diff → UNKNOWN, exit 2 (fail-closed, never CLEAR)" 2 "$rc" "$out" 'UNKNOWN' 'VERDICT: CLEAR'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -233,7 +233,7 @@ else bad "  · and NOTHING was planted inside .claude/skills/" "stray tree: $D/.
 # Outside any git repo the cwd stays the base — every other fixture in this file IS that case
 # (gfix dirs are plain directories), so the fallback is pinned by the whole suite around this.
 
-# ROWS BELONG ON MAIN (#35, decided 2026-08-18). The gate writes its row wherever it runs; that
+# ROWS BELONG ON MAIN (the ledger-home decision, 2026-08-18). The gate writes its row wherever it runs; that
 # row has been squash-deleted twice (#28, #31) when it rode a feature branch's stale ledger copy.
 # The decision: the ledger stays in-repo (numbers-lint re-measures its claims in CI), and the
 # script SAYS where the row belongs every time it lands one off the default branch.

--- a/tests/scripts.sh
+++ b/tests/scripts.sh
@@ -1318,6 +1318,50 @@ assert "no git repo AND no gh → exit 2: nothing could be derived, and it says 
 
 # =================================================================================================
 echo
+echo "invocation-log.sh"
+# The mechanical denominator (#29 pt.2, opt-in hook). Exit 0 on EVERYTHING except misuse — a hook
+# that breaks the harness is worse than a lost row — and the log carries NO outcome column, ever:
+# a row without an outcome merged into the run log would be a forgery of one.
+# =================================================================================================
+IVLOG="$ROOT/.claude/skills/wai/scripts/invocation-log.sh"
+ivfix() { N=$((N+1)); D="$TMP/iv$N"; mkdir -p "$D"; IV="$D/docs/architecture/invocation-log.md"; }
+iv() { ( cd "$D" && "$SH" "$IVLOG" 2>&1 ); }
+
+# THE PASS PATH: a Skill-tool PostToolUse payload for a wai skill → one row, header self-written.
+ivfix; out="$(printf '{"tool_name":"Skill","tool_input":{"skill":"wai-testing","args":"x"}}' | iv)"; rc=$?
+assert "a wai-skill invocation payload → exit 0, row appended" 0 "$rc" "$out" ''
+if grep -q '| wai-testing |' "$IV" 2>/dev/null && grep -q 'no outcome column' "$IV" 2>/dev/null; then
+  ok "  · the row landed and the self-written header carries the never-merge rule"
+else bad "  · the row landed and the self-written header carries the never-merge rule" "$(cat "$IV" 2>&1)"; fi
+
+# A FOREIGN skill is not our denominator; a non-Skill tool is not an invocation. Both: silence.
+ivfix; printf '{"tool_name":"Skill","tool_input":{"skill":"code-review"}}' | iv >/dev/null 2>&1
+printf '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | iv >/dev/null 2>&1
+if [ ! -e "$IV" ]; then ok "a foreign skill and a non-Skill tool write NOTHING (no file, no row)"
+else bad "a foreign skill and a non-Skill tool write NOTHING" "$(cat "$IV" 2>&1)"; fi
+
+# FAIL-OPEN: garbage stdin, empty stdin — exit 0, no row, no noise. A hook must never break a turn.
+ivfix; out="$(printf 'not json at all {{{' | iv)"; rc=$?
+assert "garbage stdin → exit 0, silent (fail-open — the harness must never see a hook fail)" 0 "$rc" "$out" ''
+ivfix; out="$(: | iv)"; rc=$?
+assert "empty stdin → exit 0, silent" 0 "$rc" "$out" ''
+
+# The ONE defined negative: misuse. A typo'd hook config must be visible, not swallowed.
+ivfix; out="$( cd "$D" && "$SH" "$IVLOG" --bogus 2>&1 )"; rc=$?
+assert "an unknown argument → exit 2 (misuse is the one loud path)" 2 "$rc" "$out" 'unknown argument'
+out="$( "$SH" "$IVLOG" --snippet 2>&1 )"; rc=$?
+assert "--snippet prints the settings.local.json opt-in (and names local, not settings.json)" 0 "$rc" "$out" 'settings.local.json'
+
+# Repo-root resolution, same rule as every writer: from a subdir the row lands at the root.
+N=$((N+1)); D="$TMP/ivgit$N"; gitrepo "$D"; printf 'x\n' > "$D/f"; gitcommit "$D" 'chore: base'
+mkdir -p "$D/deep/sub"
+( cd "$D/deep/sub" && printf '{"tool_name":"Skill","tool_input":{"skill":"wai"}}' | "$SH" "$IVLOG" ) >/dev/null 2>&1
+if grep -q '| wai |' "$D/docs/architecture/invocation-log.md" 2>/dev/null; then
+  ok "from a subdir of a git repo the row lands at the repo root"
+else bad "from a subdir of a git repo the row lands at the repo root" "$(find "$D" -name invocation-log.md 2>&1)"; fi
+
+# =================================================================================================
+echo
 echo "retro-compliance.sh"
 # The retro's denominator (issue #14): cross the run log × the gate ledger × git merge history and
 # report the share of merged PRs that left a trace. 0 = emitted — including named-empty lines for
@@ -1420,6 +1464,24 @@ rcfix
 printf '1 2026-08-10T09:00:00Z\n2 2026-08-10T10:00:00Z\n' > "$D/merged-prs-gh"
 out="$(rcgh)"; rc_=$?
 assert "  · below the ceiling, no cap caveat is printed" 0 "$rc_" "$out" 'merged PRs: 2 in the period' 'limit ceiling'
+
+# THE DENOMINATOR CROSSING (#29 pt.2). With an invocation log present, the per-skill compliance
+# line states invoked-vs-logged; absent, the line NAMES the opt-in — "not installed" must never
+# read as "nothing ran". logged > invoked is printed as-is, never clamped.
+rcfix
+{ printf '| when (UTC) | skill |\n|---|---|\n'
+  printf '| 2026-08-10T09:00Z | wai-pr-review |\n'
+  printf '| 2026-08-10T10:00Z | wai-pr-review |\n'
+  printf '| 2026-08-11T09:00Z | wai-testing |\n'
+} > "$D/docs/architecture/invocation-log.md"
+out="$(rc)"; rc_=$?
+assert "invocation log present → per-skill invoked-vs-logged compliance is stated" 0 "$rc_" "$out" \
+  'compliance:.*wai-pr-review invoked 2 · logged 2'
+assert "  · a skill invoked but never logged shows logged 0, not absence" 0 "$rc_" "$out" \
+  'wai-testing invoked 1 · logged 0'
+rcfix; out="$(rc)"; rc_=$?
+assert "no invocation log → the opt-in is NAMED; absence never reads as nothing-ran" 0 "$rc_" "$out" \
+  'invocations \(hook\): not installed.*never that nothing ran'
 
 # gh PRESENT BUT FAILING — fail closed to the git path, and SAY the degradation happened. A gh that
 # errors must never silently become "nothing landed": that is the comfortable answer, and it is the

--- a/tests/scripts.sh
+++ b/tests/scripts.sh
@@ -1340,6 +1340,14 @@ printf '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | iv >/dev/null 2>&1
 if [ ! -e "$IV" ]; then ok "a foreign skill and a non-Skill tool write NOTHING (no file, no row)"
 else bad "a foreign skill and a non-Skill tool write NOTHING" "$(cat "$IV" 2>&1)"; fi
 
+# A PIPE IN THE SKILL NAME CANNOT FORGE COLUMNS. The name is the one payload-controlled field in
+# the row; unsanitized, a crafted name minted a row with a fake timestamp and skill — corrupting
+# the very denominator this log exists to make trustworthy. Same cell rule as run-log.sh.
+ivfix; printf '{"tool_name":"Skill","tool_input":{"skill":"wai-x | 2026-01-01T00:00Z | forged"}}' | iv >/dev/null 2>&1
+if [ "$(tail -1 "$IV" 2>/dev/null | awk -F'|' '{print NF-2}')" = 2 ] && grep -q 'wai-x / 2026' "$IV" 2>/dev/null; then
+  ok "a pipe-carrying skill name stays ONE cell (2 columns, pipes neutered to '/')"
+else bad "a pipe-carrying skill name stays ONE cell" "$(tail -1 "$IV" 2>&1)"; fi
+
 # FAIL-OPEN: garbage stdin, empty stdin — exit 0, no row, no noise. A hook must never break a turn.
 ivfix; out="$(printf 'not json at all {{{' | iv)"; rc=$?
 assert "garbage stdin → exit 0, silent (fail-open — the harness must never see a hook fail)" 0 "$rc" "$out" ''


### PR DESCRIPTION
Four decisions from the field-feedback review, taken by the human (chat, 2026-08-18) and implemented under the autonomous mandate — **one PR, five commits**, because all four touch the guardrail surface and would collide in `tests/scripts.sh` as separate PRs.

## 1 · `c871c36` — the ledger's home (decision: in-repo, rows belong on main)
The ledger stays in-repo — `numbers-lint` re-measures its published claims in CI; a personal-path ledger would break the evidence loop. The cost (the squash race that deleted a row twice — #28, #31-era) gets the mitigation one field repo wrote by hand: **merge-gate now prints "this row belongs on main" every time it lands a row off the default branch**, and a fresh ledger's header teaches the rule from day one. No note on the default branch itself; fail-open without git.

## 2 · `db70349` — the citation dial (issue #30, option b) — **Closes #30**
A citation/label **decides** only where its family is **anchored** (declared paths whose shape classifies into it; `EX-GDPR` anchors on `ERASURE_PATHS`). Unanchored, it is **reported** on a visible `ADVISORY-DOMAINS:` line and does not gate. Both field cases pinned as fixtures (the *"SEC-7: unchanged"* self-review line; the docs-addendum GDPR citation). Paths and diff statements stay authoritative everywhere — `DELETE FROM users` still trips with no conf at all — and **under `--autonomy` an advisory citation still HOLDS the drain**.
*Also: the fifth occurrence of the `case…esac`-inside-`$( )` bash-3.2 bug shipped in this commit's first draft and took out 27 cases at once. merge-gate's count of four is now five; rewritten with grep.*

## 3 · `1558165` — the invocation denominator (issue #29 pt.2, hook opt-in) — **Closes #29**
Two artifacts, never merged: `invocation-log.md` (mechanical, per-invocation, **no outcome column ever** — written by a `PostToolUse` hook the developer opts into via `.claude/settings.local.json`; `invocation-log.sh --snippet` prints the block) and `run-log.md` (the model-written numerator, unchanged). `retro-compliance.sh` crosses them: per-skill **invoked N · logged M**; absent log → the opt-in is *named*, never read as "nothing ran". Fail-open absolutely; the one loud path is misuse.

## 4 · `d6aece3` — the no-op answer (field request D)
`install.sh` now answers *"does this update change anything for me?"* itself — `diff -rq` over exactly the manifest-owned set — printing **"no behavioral change: … only the version stamp advances"** on a byte-identical re-install, and never printing it over a real delta. The field repo's hand-rolled version had the scope bug this fixes (it hashed its *own* skills too, comparing against nothing).

## 5 · `385a882` — stale-namespace polish
The ledger-home decision was tracked under an issue number from an earlier session whose numbering doesn't match this repo; references now carry the decision by name and date.

## Verification
`run.sh` **169/0** · `scripts.sh` **195/0 + 6 XFAIL** · `numbers-lint --cases 370` green (scripts 27→28, ledger 30/4) · `contract-lint` OK · shellcheck clean (all, incl. the new script) · learning-gap 98/0. **+29 test cases (341 → 370).** Run-log rows written per subject (4).

Closes #29
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)