### PR TITLE
refactor(scripts): rationale pass 2 — seventeen more scripts move their narrative to docs/rationale/

### DIFF
--- a/.claude/skills/wai-init/scripts/catalog-variant.sh
+++ b/.claude/skills/wai-init/scripts/catalog-variant.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env sh
 # catalog-variant.sh — derive a catalog VARIANT from the one master baseline.
 #
-# The suite offers the quality catalog in three sizes, and the obvious way to ship that — three
-# hand-maintained files — is the failure mode this repo documents everywhere else: a SEC fix that
-# lands in two copies out of three is a silent drift nobody notices, because a stale catalog reads
-# exactly like a current one. So there is ONE master (`quality-attributes.baseline.md`) and this
-# script derives the variants from it. The checked-in variant files exist so a reader can read
-# them and `wai-init` can copy them; tests/run.sh regenerates and diffs them, so they cannot
-# drift from the master without CI going red.
+# There is ONE master (`quality-attributes.baseline.md`) and this script derives the three
+# variants from it — never three hand-maintained files. The checked-in variant files exist so a
+# reader can read them and `wai-init` can copy them; tests/run.sh regenerates and diffs them, so
+# they cannot drift from the master without CI going red.
+# Why: docs/rationale/catalog-variant.md § One master, derived variants
 #
 #   platform  — today's full build: backend + web + iOS + Android, AI model integrations,
 #               token economy. The master, verbatim, behind a variant banner.

--- a/.claude/skills/wai-init/scripts/coordination-lint.sh
+++ b/.claude/skills/wai-init/scripts/coordination-lint.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env sh
 # coordination-lint.sh — is this repo's autonomy + comms config safe to act on?
 #
-# `coordination.conf` decides what an agent may do WITHOUT a human: arm an autonomous drain, post to a
-# channel. A config that is wrong in the SAFE direction (autonomy off) costs nothing. A config that is
-# wrong in the UNSAFE direction — a narrowed exclusion floor, an allowlist that authorises too much, a
-# webhook SECRET committed in the clear — costs everything, silently, and looks identical to a working
-# one. So the config gets the same treatment as the merge gate: a script owns the mechanical checks,
-# because "the model read the config and it looked fine" is not something anyone can audit.
+# `coordination.conf` decides what an agent may do WITHOUT a human: arm an autonomous drain, post to
+# a channel. A script owns the mechanical checks — "the model read the config and it looked fine" is
+# not something anyone can audit.
+# Why: docs/rationale/coordination-lint.md § Wrong in the unsafe direction looks identical to working
 #
 # THE ONE INVARIANT THIS FILE PROTECTS: the six policy domains that stay the human's in EVERY mode may
 # only ever be WIDENED, never narrowed. And the floor is NOT typed here — a second copy of a security

--- a/.claude/skills/wai-init/scripts/mine-issues.sh
+++ b/.claude/skills/wai-init/scripts/mine-issues.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env sh
 # mine-issues.sh — the read-only signal an existing backlog already carries about THIS repo.
 #
-# wai-init writes a quality catalog. Left to a cold read of the code, it proposes the dimensions
-# the code SHAPE suggests — and misses the ones the team has been feeling for months but that leave no
-# structural trace: the label people keep reaching for, the word that recurs across a dozen bug
-# titles, the theme half the closed PRs share. That history is evidence, and evidence a catalog author
-# never sees is a catalog dimension never written. This script surfaces it — as COUNTS the model then
-# judges, never as a verdict.
+# The backlog carries quality signal a cold read of the code cannot see; this script surfaces it —
+# as COUNTS the model then judges, never as a verdict.
+# Why: docs/rationale/mine-issues.md § The backlog is evidence a cold read of the code misses
 #
 # WHAT IT EMITS (and nothing more):
 #   LABEL_FREQ         — how often each issue label is used, with up to 3 example issue NUMBERS.
@@ -16,11 +13,10 @@
 #   CLOSED_PR_THEMES   — the labels and title terms that recur across CLOSED PRs — what the team has
 #                        actually been merging fixes FOR.
 #
-# WHAT IT REFUSES TO DO — and why the refusal is the point:
-#   * It prints NUMBERS, never bodies. An issue body is the most PII-dense text in a repo (stack traces
-#     with usernames, customer emails, tokens pasted in a hurry). Mining it wholesale into a catalog
-#     proposal would launder that PII into a committed doc. Bodies are read ONLY behind --bodies, ONLY
-#     to widen the TERM_DF corpus, and every email-shaped token is redacted before it is ever tokenised.
+# WHAT IT REFUSES TO DO:
+#   * It prints NUMBERS, never bodies. Bodies are read ONLY behind --bodies, ONLY to widen the
+#     TERM_DF corpus, and every email-shaped token is redacted before it is ever tokenised.
+#     Why: docs/rationale/mine-issues.md § An issue body is the most PII-dense text in a repo
 #   * It does NOT decide whether a signal is a real quality concern, nor whether to extend a dimension,
 #     mint a new local ID (>=100), propose it upstream, or drop it. That is model judgment on LOCAL
 #     ID space (ADR-0003: an ID inside an issue resolves against THIS repo's catalog, never a baseline).
@@ -29,11 +25,9 @@
 #   exit 2  UNKNOWN: gh missing / unauthenticated / the origin is not a GitHub repo gh can resolve.
 #           Not a failure of THIS repo — a failure to reach the signal. The caller degrades to
 #           code-only mining and records the gap. (2 is the suite's UNKNOWN across the gh emitters.)
-#   (There is deliberately no exit 3. "You ran me in the wrong place" and "I could not reach
-#   GitHub" are different FACTS, but they are the same DECISION for the caller: do not trust the
-#   mining, fall back to code-only. The distinction belongs in the message, not the exit code —
-#   and the suite's precedent is settled: excluded-domains.sh and merge-gate.sh both map misuse
-#   to 2. A private fourth code makes every caller learn a per-script dialect.)
+#   (There is deliberately no exit 3: misuse maps to 2, the same as excluded-domains.sh and
+#   merge-gate.sh — do not add a private fourth code. The distinction lives in the message.)
+#   Why: docs/rationale/mine-issues.md § Why there is no exit 3
 #
 # Usage: sh mine-issues.sh [--since YYYY-MM-DD] [--limit N] [--bodies]
 #        (default: --limit 200, all dates, titles+labels only)

--- a/.claude/skills/wai-learning-gap/scripts/install-hook.sh
+++ b/.claude/skills/wai-learning-gap/scripts/install-hook.sh
@@ -87,9 +87,8 @@ MARKER="wai-learning-gap pre-commit (personal, auto-installed)"
 # The gap marker, assembled — NEVER written here as one contiguous string. This file generates a
 # hook that greps for the marker, so writing the literal would put it in the tree, where every
 # marker-scanner (this suite's own open-gap-check, and the hook itself once the suite is vendored
-# into a repo) would match it as if it were a real open exercise. That is not hypothetical: it
-# blocked a human's commit in the field, and it made open-gap-check unable to ever say "safe to
-# plant" in any repo that carries .claude/skills/.
+# into a repo) would match it as if it were a real open exercise.
+# Why: docs/rationale/install-hook.md § The literal marker blocked a commit in the field
 GAP_WORD='LEARN'
 
 # --- Chain a pre-existing FOREIGN hook ----------------------------------------------------------

--- a/.claude/skills/wai-learning-gap/scripts/ledger-lint.sh
+++ b/.claude/skills/wai-learning-gap/scripts/ledger-lint.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env sh
 # ledger-lint.sh — the third operation on the personal ledger.
 #
-# A ledger has ingest (the skill WRITES rows) and query (it READS boxes to choose a gap). It never
-# had a lint — the same hole catalog-lint.sh was written to close, one level down. So an axis label
-# could be a typo the box-weighting silently ignores, an enabled axis could carry no level, two
-# gaps could be open at once, and a Socratic gap could record NO expected answer — which is fatal,
-# because a Socratic gap stays GREEN (it removes no code): its ONLY proof of a solve is the
-# comparison against a recorded expected answer, and if none was recorded the gap can never be
-# closed and rides along invisibly. Nothing checked. This checks.
+# A ledger has ingest (the skill WRITES rows) and query (it READS boxes to choose a gap); this is
+# the lint. It checks: every axis label is in the enum, an enabled axis carries a level, at most
+# ONE gap is open, and a Socratic gap records its expected answer. The last is load-bearing: a
+# Socratic gap stays GREEN (it removes no code), so its ONLY proof of a solve is the comparison
+# against the recorded expected answer — without one the gap can never be closed.
+# Why: docs/rationale/ledger-lint.md § The same hole catalog-lint closed, one level down
 #
 # IT NEVER REWRITES A LEDGER. An existing ledger belongs to the human — including a human-authored
 # one whose shape differs from the template (different section names, another language). This lint

--- a/.claude/skills/wai-learning-gap/scripts/ledger-locate.sh
+++ b/.claude/skills/wai-learning-gap/scripts/ledger-locate.sh
@@ -3,15 +3,10 @@
 #
 # THE LEDGER IS THE CONSENT. Learning mode is active for exactly one person: the one who has a
 # personal ledger for this repo. No ledger anywhere → the skill must do NOTHING (plant no gap,
-# install no hook, create nothing) so a colleague who never opted in stays untouched. That gate is
-# load-bearing, and it has one invisible failure mode the skill's own prose warns about:
-#
-#   A slug is DERIVED (from the remote, or the folder), and derived things drift — the repo is
-#   transferred to an org, renamed, forked; the folder is moved. A naive path check then finds no
-#   ledger at the new slug and concludes "this human never opted in" — going silent, orphaning
-#   their Leitner state, and by the very design of the gate NOBODY is told. So the gate is a
-#   LOOKUP, not a path check: it also reads what each ledger RECORDS about the repo it belongs to
-#   (its remote URL, its owner/repo) and matches on THAT, which does not drift.
+# install no hook, create nothing) so a colleague who never opted in stays untouched. And the gate
+# is a LOOKUP, not a path check: it also reads what each ledger RECORDS about the repo it belongs
+# to (its remote URL, its owner/repo) and matches on THAT, which does not drift when the slug does.
+# Why: docs/rationale/ledger-locate.md § A derived slug drifts, and the gate goes silent
 #
 # This is the single owner of that lookup. wai-team's post-run learning hand-off routes
 # through it; it does not re-implement the consent check.

--- a/.claude/skills/wai-learning-gap/scripts/open-gap-check.sh
+++ b/.claude/skills/wai-learning-gap/scripts/open-gap-check.sh
@@ -1,19 +1,15 @@
 #!/usr/bin/env sh
 # open-gap-check.sh — at most ONE open gap, checked on BOTH sides in one call.
 #
-# The invariant is "never plant a second gap while one is open". It has to be checked on two sides,
-# and the skill's prose says why the ledger alone is not enough:
+# The invariant is "never plant a second gap while one is open", checked on two sides in one call:
+# the working TREE (git grep for the gap marker) is the side that catches a concurrent second
+# plant, and the ledger is the side that catches a marker a human deleted without solving. Neither
+# side alone is enough.
+# Why: docs/rationale/open-gap-check.md § Two sides, because the ledger has no lock
 #
-#   The ledger is a single unlocked file shared across every clone and worktree of a repo. Two
-#   concurrent sessions both read "no open row" and both plant — so the working TREE (`git grep`
-#   for the gap marker) is the side that actually catches a second gap, and the ledger is the
-#   side that catches a marker a human deleted without solving. You need both.
-#
-# WHY THE EXIT CODE IS 0/1/2 AND NOT A BITMASK. A tempting design folds "which side" into the exit
-# code (2 = ledger-side open). That is exactly the bug the merge gate exists to warn about: it
-# steals the UNKNOWN code — the suite's universal "could not verify, fail closed" — and makes the
-# gate misreport which of its own states it is in. So the SIDE goes in stdout, where it is data,
-# and 2 keeps its one meaning: something could not be read.
+# The SIDE that is open goes to stdout, where it is data — never into the exit code. Exit 2 keeps
+# its one suite-wide meaning: something could not be read.
+# Why: docs/rationale/open-gap-check.md § The exit code is not a bitmask
 #
 #   exit 0  no gap is open on either side — it is safe to plant
 #   exit 1  a gap IS open — stdout names WHICH side (this tree, ANOTHER worktree, and/or ledger);
@@ -22,33 +18,23 @@
 #
 # What this does NOT decide: anything judgmental — only whether an open gap exists, and where.
 #
-# A MARKER DETECTOR MUST NOT CONTAIN ITS OWN MARKER. This script used to grep for the literal
-# string, which meant the literal was IN this file — so it matched itself, and it matched every
-# other file that handles the marker as data (the hook installer, the test fixtures). Since
-# `.claude/skills/**` is committed in every repo install.sh has touched, the result was that
-# learning mode could NEVER plant a gap in a repo that vendors the suite: exit 1, "resolve the open
-# gap first", and nothing to resolve. Assembling the pattern at run time is the fix that needs no
-# path exclusions — and a blanket `:!.claude/skills/*` would have been wrong anyway, because this
-# repo is itself a project someone may legitimately be learning on.
+# A MARKER DETECTOR MUST NOT CONTAIN ITS OWN MARKER: the pattern is assembled at run time on the
+# next two lines, so the literal never appears in this file. Do NOT join them into one string.
+# Why: docs/rationale/open-gap-check.md § The detector used to contain its own marker
 MARKER_WORD='LEARN'
 MARKER="$MARKER_WORD #"
 #
 # THE TREE SIDE SWEEPS EVERY WORKTREE, NOT JUST ITS OWN. The ledger hangs off the repo and is
-# shared across all worktrees; a working tree is not. This script used to grep only the tree it ran
-# in, so the two sides it compares had different reach — and in the field (issue #13) that cost two
-# days: a gap planted from a linked worktree was invisible in the main checkout, the check reported
-# only the ledger row, and flow B's "no marker + no claim = expired" booked an exercise the human
-# had never seen. "No marker HERE" and "no marker ANYWHERE" are different facts. So the sweep walks
-# `git worktree list --porcelain`; a marker found in ANOTHER tree is reported as misplaced (exit 1,
-# its own line), and a listed tree that cannot be read makes the verdict UNKNOWN (exit 2) — an
-# unswept tree is never silently counted as clear.
+# shared across all worktrees; a working tree is not — the two sides must have the same reach. So
+# the sweep walks `git worktree list --porcelain`; a marker found in ANOTHER tree is reported as
+# misplaced (exit 1, its own line), and a listed tree that cannot be read makes the verdict
+# UNKNOWN (exit 2) — an unswept tree is never silently counted as clear.
+# Why: docs/rationale/open-gap-check.md § The sweep used to stop at its own worktree
 #
 # Usage:  sh open-gap-check.sh [ledger-path]
 #   With no argument the ledger is located the same way the skill locates it — via
-#   ledger-locate.sh — NOT by guessing one path. Guessing the `temp/` fallback meant that for a
-#   normal participant (whose ledger is under ~/.claude/learning/) the ledger side was skipped
-#   entirely while the output still announced "tree and ledger both clear". A green that names a
-#   side it never read is the exact thing ADR-0002 forbids.
+#   ledger-locate.sh — NOT by guessing one path.
+# Why: docs/rationale/open-gap-check.md § A green that named a side it never read
 
 set -u
 if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi
@@ -170,8 +156,8 @@ if [ -n "$UNKNOWN" ]; then
   exit 2
 fi
 
-# Say exactly which sides were read. "Both clear" when one side was never located is the claim this
-# script was caught making.
+# Say exactly which sides were read — never claim "both clear" for a side that was never located.
+# Why: docs/rationale/open-gap-check.md § A green that named a side it never read
 case "$LEDGER_SOURCE" in
   none) echo "open-gap-check: tree clear; no ledger claims this repo (nobody opted in) — safe to plant." ;;
   *)    echo "open-gap-check: no open gap on either side (tree clear, ledger $LEDGER clear) — safe to plant." ;;

--- a/.claude/skills/wai-learning-gap/scripts/tests/run.sh
+++ b/.claude/skills/wai-learning-gap/scripts/tests/run.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env sh
 # tests/run.sh — the wai-learning-gap scripts, tested on TWO shells.
 #
-# These scripts are the ADR-0002 mechanics of a skill that had none: the opt-in gate, the one-open-
-# gap invariant, the "a gap must go red" probe, the ledger lint, the hook installer, the order-
-# neutraliser, and the post-run PR shortlist. Each is a gate or an emitter, and the suite has
-# already paid, twice, for the two ways a shell gate ships broken:
+# Under test: the opt-in gate, the one-open-gap invariant, the "a gap must go red" probe, the
+# ledger lint, the hook installer, the order-neutraliser, and the post-run PR shortlist. Each is a
+# gate or an emitter, and two rules govern every case:
 #
 #   · A `case … esac` inside `$( )` is a syntax error in bash 3.2 — which is what /bin/sh IS on
 #     macOS — and shellcheck passes it. So every case here runs under BOTH dash and bash 3.2.
 #   · A gate you have only ever seen FAIL is not a validated gate. So every script is exercised on
 #     its GO path (exit 0) as deliberately as on its NO path — an open-gap check that has never
 #     said "safe to plant" is an untested branch that happens to be failing closed.
+#
+# Why: docs/rationale/learning-gap-tests.md § The suite paid twice for shell gates before these rules existed
 #
 # Self-contained: no network, gh is stubbed, git repos are built in a temp dir, the classifier is
 # stubbed via EXCLUDED_DOMAINS_SH. Run:  sh tests/run.sh
@@ -222,8 +223,8 @@ for SH in $SHELLS; do
   assert "$SH open-gap: a named ledger it cannot read → 2 (UNKNOWN)" 2 "$rc" "$out" 'could not read'
 
   # THE WORKTREE SWEEP (issue #13): the ledger is shared across every worktree, the trees are not —
-  # a check that greps only its own tree compares two sides with different reach, and a marker
-  # planted from a linked worktree sat invisible for two days while flow B booked it `expired`.
+  # a check that greps only its own tree compares two sides with different reach.
+  # Why: docs/rationale/learning-gap-tests.md § The marker that sat invisible in a linked worktree
   Rwt="$TMP/ogwt-$SH"; gitrepo "$Rwt"
   Wsec="$TMP/ogwt-second-$SH"
   git -C "$Rwt" worktree add -q "$Wsec" -b "wt-$SH" >/dev/null 2>&1

--- a/.claude/skills/wai-learning-gap/scripts/verify-gap-breaks.sh
+++ b/.claude/skills/wai-learning-gap/scripts/verify-gap-breaks.sh
@@ -4,9 +4,9 @@
 # The whole mechanism rests on one promise: after a gap is planted, build/tests go RED, so the
 # human KNOWS a line is missing and has something concrete to restore. A gap that leaves the tree
 # green is worse than no gap — the human never notices it, the marker rides along into the next
-# commit unseen, and the Leitner box gets promoted for an exercise nobody did. The skill used to
-# assert "the gap must fail visibly" in prose and hope the model checked. "The model checked" is
-# not auditable. This is: it RUNS the project's own test command and reads the exit code.
+# commit unseen, and the Leitner box gets promoted for an exercise nobody did. So the check is
+# mechanical and auditable: this script RUNS the project's own test command and reads the exit code.
+# Why: docs/rationale/verify-gap-breaks.md § The red-probe replaced a prose promise
 #
 # The one subtlety, and the reason this is not just `! test`: the Socratic architecture gap
 # (see references/axes.md) is a NON-removal form. It asks the human to explain a structural choice;

--- a/.claude/skills/wai-pr-review/scripts/gate-stats.sh
+++ b/.claude/skills/wai-pr-review/scripts/gate-stats.sh
@@ -5,16 +5,10 @@
 # HUMAN tagged (the outcomes). That split is the whole design: a number no one can forge, and a
 # judgment no script can fake. See docs/learnings/empirical-test-plan.md §0–1.
 #
-# ── TAGS ARE MATCHED ON THEIR FIRST TWO CHARACTERS, AND THE ZERO THAT TAUGHT US WHY ──────────────
-#
-# The first parser compared outcome tags LITERALLY: `outcome["NO-GO/ok"]`. Then a three-week field
-# ledger arrived (issue #10) in which the human's vocabulary was finer than two letters — `fp, bug`,
-# `ok, besser GO`, `ok, manual fix` — and none of it was `ok` or `fp` to a string comparison. Twenty
-# of fifty-two judged NO-GO rows fell out of the statistic, unannounced, and the output read
-# "false-positive rate: 0%". The true value was 15%. The zero was not a measurement; it was a parser
-# artifact, sitting in the very line meant to prove the gate trustworthy. So: the tag is the first
-# two characters, the free text after a comma is the human's and is preserved — and any tag this
-# parser cannot place is COUNTED AND PRINTED. A statistic that drops rows must say so.
+# Tags are matched on their FIRST TWO characters, never compared literally. The free text after a
+# comma is the human's and is preserved — and any tag this parser cannot place is COUNTED AND
+# PRINTED. A statistic that drops rows must say so.
+# Why: docs/rationale/gate-stats.md § The 0% that was 15%
 #
 #   exit 0  printed the numbers (or the report)
 #   exit 2  no ledger to read — also under --report: never 0 with empty output
@@ -40,8 +34,8 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
-# Default is REPO-relative (see merge-gate.sh — the writer this reads; resolving from the cwd
-# made a documented invocation report "no ledger" over a repo that had 28 rows, a false blank).
+# Default is REPO-relative, never cwd-relative (see merge-gate.sh — the writer this reads).
+# Why: docs/rationale/gate-stats.md § The cwd default that reported a false blank
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$LEDGER" ] || LEDGER="${REPO_ROOT:-.}/docs/architecture/gate-ledger.md"
 
@@ -76,9 +70,9 @@ awk -F'|' -v report="$REPORT" -v today="$(date -u +%Y-%m-%d 2>/dev/null || echo 
     while (match(s, /EX-[A-Z]+/)) { ex[substr(s, RSTART, RLENGTH)]++; s = substr(s, RSTART + RLENGTH) }
 
     # Mechanical cause classification of every NO-GO why cell. index(), not regex — these are
-    # literal phrases the gate itself prints, parens and all. Precedence setup > checks > domain,
-    # matching how the field report counted (a row failing on environment AND domain is an
-    # environment problem first — the remedy the gate prints 55 times is "declare required checks").
+    # literal phrases the gate itself prints, parens and all. Precedence setup > checks > domain:
+    # a row failing on environment AND domain is an environment problem first.
+    # Why: docs/rationale/gate-stats.md § Why setup outranks checks outranks domain
     if (v == "NO-GO") {
       if (index(w, "declares no required status checks") || index(w, "no enforced approval") || \
           index(w, "no CI checks report") || index(w, "run wai-init before"))
@@ -94,8 +88,8 @@ awk -F'|' -v report="$REPORT" -v today="$(date -u +%Y-%m-%d 2>/dev/null || echo 
     if (p == "ok") {
       okc[v]++
       # `ok, besser GO` is the calibration signal: the block was correct by the rules, but the
-      # human says GO would have been fine. Eleven of these sat unread in the field ledger while
-      # the gate went unchanged for three weeks — the most precise feedback a gate can get.
+      # human says GO would have been fine.
+      # Why: docs/rationale/gate-stats.md § Eleven besser-GO rows sat unread for three weeks
       if (v == "NO-GO" && index(o, "ok, besser GO") == 1) besser++
     }
     else if (p == "fp") fpc[v]++

--- a/.claude/skills/wai-retro/scripts/retro-compliance.sh
+++ b/.claude/skills/wai-retro/scripts/retro-compliance.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env sh
 # retro-compliance.sh — the retro's denominator: did the period's work leave a trace?
 #
-# Issue #10, Part B, measured in the field: a skill left a trace ONLY if it filed something, so the
-# record measured the side effects of work, not the work. The run log (issue #11) is the fix — one
-# appended row per run — but the run log's own writers are split in two tiers, and the second tier
-# is PROSE: a skill's SKILL.md says "log the run at hand-back", and nothing checks that the model
-# obeyed. That is the suite's own prompt-contract weakness, pointed at itself. This script is the
-# check: it crosses the three artifacts that exist independently of each other — the run log (what
-# claims to have run), the gate ledger (what the gate demonstrably emitted) and `git log --merges`
-# (what demonstrably landed) — and reports the share of merged PRs that carry a gate verdict, with
-# every raw count printed beside the rate. A merged PR with no verdict row is a review that either
-# never ran or ran without its script; the ledger cannot tell those apart, and this line is where
-# that gap becomes visible instead of comfortable.
+# The run log's writers are split in two tiers, and the second tier is PROSE: a skill's SKILL.md
+# says "log the run at hand-back", and nothing checks that the model obeyed. That is the suite's
+# own prompt-contract weakness, pointed at itself. This script is the check: it crosses the three
+# artifacts that exist independently of each other — the run log (what claims to have run), the
+# gate ledger (what the gate demonstrably emitted) and `git log --merges` (what demonstrably
+# landed) — and reports the share of merged PRs that carry a gate verdict, with every raw count
+# printed beside the rate. A merged PR with no verdict row is a review that either never ran or
+# ran without its script; the ledger cannot tell those apart, and this line is where that gap
+# becomes visible instead of comfortable.
+# Why: docs/rationale/retro-compliance.md § The record measured side effects, not work
 #
 # ADR-0002, and the reason this script does not self-log: it EXTRACTS, it does not run a skill.
 # run-log.sh's own header restricts self-logging to scripts whose script↔skill mapping marks a real
@@ -169,12 +168,9 @@ fi
 
 # ── merged PRs in the period ─────────────────────────────────────────────────────────────────────
 # TWO ENUMERATORS, AND THEY ARE DIFFERENT MEASUREMENTS. `git log --merges` reads merge COMMITS: a
-# squash- or rebase-merged PR leaves none. That is offline and deterministic, and it was the only
-# source — which inverted the metric's purpose on any repo that squash-merges. On this repo PRs
-# #1–#6 were merge-committed and everything since #15 was squashed, so the live traced share (5/5 =
-# 100%) covered only the era that PREDATES the metric, and the very gap that motivated it (#15/#16
-# merged without gate verdicts) was invisible. A denominator that silently excludes the population
-# it was built to measure is worse than no denominator. (#24)
+# squash- or rebase-merged PR leaves none, so on a squash-merging repo it enumerates the wrong
+# population.
+# Why: docs/rationale/retro-compliance.md § The merge-commit denominator inverted the metric
 #
 # So: prefer `gh pr list --state merged` when gh is available and authenticated — it counts a
 # squash merge exactly like a merge commit — and fall back to `git log --merges` otherwise, with
@@ -236,8 +232,8 @@ fi
 
 # ── the traced share ─────────────────────────────────────────────────────────────────────────────
 # Of the merged PRs whose number is readable, how many carry a gate verdict row in the period? The
-# raw counts stand beside the rate (principle: every metric needs a counter-reader — a 0% that was
-# really 15% once shipped inside the very line meant to prove trustworthiness).
+# raw counts stand beside the rate (principle: every metric needs a counter-reader).
+# Why: docs/rationale/retro-compliance.md § A 0% that was really 15%
 if [ "$MPN" = 0 ]; then
   echo "  traced share: not derivable — 0 merged PRs with a readable number is an empty denominator, not 100% compliance (enumerator: $MERGE_SRC)$MERGE_NOTE"
 else

--- a/.claude/skills/wai-security-audit/scripts/dep-cve-scan.sh
+++ b/.claude/skills/wai-security-audit/scripts/dep-cve-scan.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env sh
 # dep-cve-scan.sh — deterministic dependency-CVE scan, per ecosystem, with a not_measured sentinel.
 #
-# The security audit asks "are there known-vuln dependencies?" The trap it kept falling into:
-# `npm audit 2>/dev/null` returning empty is INDISTINGUISHABLE from "0 CVEs" and "the scanner is not
-# installed". A tool that printed nothing may never have run. A prose instruction to "report not
-# measured if it didn't run" is the same fragile please-remember the suite moved off of — so a
-# SCRIPT decides, deterministically, whether each scan RAN, and emits `not_measured`, never a silent
-# 0, when it did not.
+# Empty scanner output is INDISTINGUISHABLE from "0 CVEs" and "the scanner is not installed" — so
+# this SCRIPT decides, deterministically, whether each scan RAN, and emits `not_measured`, never a
+# silent 0, when it did not.
+# Why: docs/rationale/dep-cve-scan.md § The empty-output trap
 #
 # THE SPLIT (ADR-0002). This script owns MECHANICS: which ecosystems are present, did the scanner
 # run, how many CVEs by severity. It does NOT own JUDGMENT — whether a given CVE is reachable or
@@ -29,8 +27,8 @@
 # an npm dependency, it is in the base image. So a clean result here is NOT a clean bill of health;
 # an IMAGE scan (trivy/grype) is the only thing that sees those two surfaces, and a runtime-bundled
 # CVE is fixed by a base-image bump, not a package update. This script prints that caveat on every
-# run so its "measured" is never mistaken for "the runtime is clean". (Field incident: undici
-# CVE-2026-12151, invisible to the dependency audit, caught only by the image scan.)
+# run so its "measured" is never mistaken for "the runtime is clean".
+# Why: docs/rationale/dep-cve-scan.md § The undici incident
 #
 # Usage: sh dep-cve-scan.sh [repo-root]        (default: .)
 
@@ -38,10 +36,10 @@ set -u
 if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi
 
 ROOT="${1:-.}"
-# Attendance (issue #11: the record measures side effects, not work — an audit that finds nothing
-# vanishes). The CVE sweep marks a wai-security-audit run and maps 1:1 to that skill, so it
+# Attendance: the CVE sweep marks a wai-security-audit run and maps 1:1 to that skill, so it
 # self-logs one row with its summary state. Resolved BEFORE the cd ($0 may be relative), as a
 # ../../wai/scripts/ sibling; FAIL-OPEN — a logging failure must never change a scan result.
+# Why: docs/rationale/dep-cve-scan.md § Why the scan self-logs
 RUNLOG_SH="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/../../wai/scripts/run-log.sh"
 runlog() { [ -f "$RUNLOG_SH" ] && sh "$RUNLOG_SH" wai-security-audit "dep CVE scan" "$1" >/dev/null 2>&1 || true; }
 cd "$ROOT" 2>/dev/null || { echo "dep-cve-scan: cannot cd to '$ROOT'" >&2; exit 2; }

--- a/.claude/skills/wai-team/scripts/backlog-scan.sh
+++ b/.claude/skills/wai-team/scripts/backlog-scan.sh
@@ -3,19 +3,17 @@
 #
 # wai-team must never self-mandate. Invoked without a named issue set, it does not claim,
 # branch, or work anything — it runs THIS, presents the overview as a proposal, and stops until the
-# human confirms the set, the decision handling, the budget and the integration mode. The reason it
-# is a script and not "the model reads the backlog": the frontier and the default order are a
-# dependency computation, and a model re-deriving a topo order by eye on every run is exactly the
-# brittle-prompt failure ADR-0002 exists to remove. Compute it once, here, and let step 2 refine a
-# single source instead of inventing its own.
+# human confirms the set, the decision handling, the budget and the integration mode. The frontier
+# and the default order are computed ONCE, here; step 2 refines this single source and never
+# re-derives its own order.
+# Why: docs/rationale/backlog-scan.md § Why a script and not the model reading the backlog
 #
 # THE ONE THING THIS SCRIPT MUST NOT DO IS RENDER A VERDICT IT CANNOT JUSTIFY.
 # `has_ac_checkboxes` is a MECHANICAL FACT — the issue body contains a `- [ ]` / `- [x]` line, or it
-# does not. It is NOT a judgment that the issue is "actionable": a checklist-free issue can be
-# perfectly workable and a checklist-heavy one can be noise. The drop/keep call stays with the model
-# (comment what's missing, label needs-info, move on — or keep it). Emitting an "actionable: no"
-# verdict from a checkbox count is the same category error as a lint that fails a repo for tailoring:
-# a mechanical signal wearing a semantic verdict's clothes. So it emits the fact and names it a fact.
+# does not. It is NOT a judgment that the issue is "actionable": the drop/keep call stays with the
+# model (comment what's missing, label needs-info, move on — or keep it). So it emits the fact and
+# names it a fact.
+# Why: docs/rationale/backlog-scan.md § A mechanical fact must not wear a verdict's clothes
 #
 # The exclusion-domain column is likewise a HINT, and says so: an issue carries no diff yet, so the
 # authoritative excluded-domain classification (wai/scripts/excluded-domains.sh, obeyed by its
@@ -37,10 +35,10 @@ if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi   # POSIX word/glo
 command -v gh >/dev/null 2>&1 || { echo "backlog-scan: gh is not installed — cannot read the backlog (UNKNOWN)." >&2; exit 2; }
 gh auth status >/dev/null 2>&1 || { echo "backlog-scan: gh is not authenticated — cannot read the backlog (UNKNOWN)." >&2; exit 2; }
 
-# Attendance (issue #11: the record measures side effects, not work — a team run that files nothing
-# vanishes). This scan opens every wai-team run and maps 1:1 to that skill, so it self-logs the row.
+# Attendance: this scan opens every wai-team run and maps 1:1 to that skill, so it self-logs the row.
 # Resolved as a ../../wai/scripts/ sibling like the shared classifier; FAIL-OPEN — a logging failure
 # must never break a scan.
+# Why: docs/rationale/backlog-scan.md § Attendance: a run that files nothing vanishes
 RUNLOG_SH="$(dirname "$0")/../../wai/scripts/run-log.sh"
 runlog() { [ -f "$RUNLOG_SH" ] && sh "$RUNLOG_SH" wai-team "backlog scan" "$1" >/dev/null 2>&1 || true; }
 

--- a/.claude/skills/wai-team/scripts/cross-issue-digest.sh
+++ b/.claude/skills/wai-team/scripts/cross-issue-digest.sh
@@ -2,13 +2,10 @@
 # cross-issue-digest.sh — the notes a team run leaves on OTHER people's issues, gathered so none
 # evaporates.
 #
-# A long run touches many issues in passing: it references #this from a comment on #that, it learns
-# that #A actually depends on #B, it discovers a real problem on an issue it is not working. The
-# landing rule says a genuine finding gets FILED — but the raw material for that decision is scattered
-# across every issue the run brushed against, and asking a model to remember, at report time, every
-# comment it made three hours ago on an issue outside the set is the please-remember pattern ADR-0002
-# retired. So a script re-reads the backlog for edits SINCE THE RUN STARTED, on issues OUTSIDE the
-# worked set, and hands back the candidates. The model curates; nothing is filed automatically.
+# The landing rule says a genuine finding gets FILED. This script re-reads the backlog for edits
+# SINCE THE RUN STARTED, on issues OUTSIDE the worked set, and hands back the candidates. The model
+# curates; nothing is filed automatically.
+# Why: docs/rationale/cross-issue-digest.md § Why a re-read and not the model's memory
 #
 # WHAT IT GATHERS (mechanical): #-references, depends-on / blocked-by relations, and the text of
 # comments added since the run's start timestamp — grouped by issue and deduped within each group.

--- a/.claude/skills/wai/scripts/invocation-log.sh
+++ b/.claude/skills/wai/scripts/invocation-log.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env sh
-# invocation-log.sh — the mechanical DENOMINATOR of skill runs (#29, decided 2026-08-18).
+# invocation-log.sh — the mechanical DENOMINATOR of skill runs.
 #
-# The run log's two tiers were measured in the field: the script-written tier logged 9 of 9; every
-# prompt-written tier had gaps (architecture-audit 0 rows with a committed report, learning-gap 0
-# with a ledger entry, implementation 4 of 5). Self-logging that depends on the model is not a
-# measurement. The fix is two artifacts, NEVER merged:
+# Self-logging that depends on the model is not a measurement, so there are two artifacts, NEVER
+# merged:
 #
 #   invocations (THIS file's output)  — every wai-* skill invocation, written MECHANICALLY by a
 #                                        harness hook. No outcome column, ever: it counts starts,
@@ -14,6 +12,7 @@
 # The difference between the two is per-skill prompt-contract compliance, and retro-compliance.sh
 # reports it. A merged artifact would be worse than either: a row without an outcome is not a
 # subset of the run log, it is a forgery of one.
+# Why: docs/rationale/invocation-log.md § The prompt-written tier was measured and had gaps (#29)
 #
 # OPT-IN, PER DEVELOPER (the learning-gap precedent): this script only runs if YOU wire it as a
 # Claude Code PostToolUse hook in your **.claude/settings.local.json** — never settings.json,
@@ -60,10 +59,9 @@ fi
 IN="$(head -c 65536 2>/dev/null || true)"
 printf '%s' "$IN" | grep -q '"tool_name"[[:space:]]*:[[:space:]]*"Skill"' || exit 0
 SKILL="$(printf '%s' "$IN" | grep -o '"skill"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"skill"[[:space:]]*:[[:space:]]*"//; s/"$//')"
-# Table-safe, like run-log.sh's cell(): the name is the ONE field this row takes from the payload,
-# and a name carrying '|' forged extra columns — a crafted skill name minted rows with a fake
-# timestamp and skill, corrupting the very denominator this log exists to make trustworthy.
+# Table-safe, like run-log.sh's cell(): the name is the ONE field this row takes from the payload.
 # Pipes become '/', whitespace collapses, 80 chars on a word boundary with a visible cut.
+# Why: docs/rationale/invocation-log.md § A crafted skill name forged denominator rows
 SKILL="$(printf '%s' "$SKILL" | tr '\n' ' ' | sed 's/|/\//g; s/[[:space:]]\{1,\}/ /g; s/^ *//; s/ *$//' \
   | awk '{ if (length($0) <= 80) print; else { s = substr($0, 1, 80); sub(/ [^ ]*$/, "", s); print s "…" } }')"
 case "$SKILL" in

--- a/.claude/skills/wai/scripts/open-items.sh
+++ b/.claude/skills/wai/scripts/open-items.sh
@@ -1,19 +1,15 @@
 #!/usr/bin/env sh
 # open-items.sh — the hand-back state footer, derived from artifacts instead of recalled.
 #
-# Issue #7, measured twice in the field: self-recall under-reports ~3× (a long session retrospected
-# from memory reported 2 of 6 verified failures — and described one of the missed ones as handled),
-# and "MERGED" is not "arrived" (a four-commit batch landed on a branch whose PR was already merged;
-# GitHub said MERGED, the default branch never saw it, found a day later by accident). A footer the
-# model writes from memory inherits exactly that bias, in the comfortable direction: an empty list
-# reads as coverage. So: THE SCRIPT EMITS, THE MODEL PASTES — every ▶ Recommended next hand-back
-# ends with this output, verbatim.
+# A footer the model writes from memory inherits self-recall's bias, in the comfortable direction:
+# an empty list reads as coverage. So: THE SCRIPT EMITS, THE MODEL PASTES — every ▶ Recommended
+# next hand-back ends with this output, verbatim.
+# Why: docs/rationale/open-items.md § Self-recall under-reports, and MERGED is not arrived (issue #7)
 #
 # THE ADR-0002 BOUNDARY, UP FRONT: this script reports FACTS — what is open, what is assigned, what
-# never arrived. "What to do next" is judgment and stays the model's ▶ Recommended next line; a
-# script that decided that would be exactly the class this repo has deleted twice.
+# never arrived. "What to do next" is judgment and stays the model's ▶ Recommended next line.
 #
-# THREE RULES make the output trustworthy (each one a measured failure without it):
+# THREE RULES make the output trustworthy:
 #   1. An empty line NAMES its derivation ("none — 0 open PRs") or prints "not checked" — an empty
 #      list without a derivation is a claim, not a statement.
 #   2. A class whose artifact is absent in this repo is SKIPPED, and the final summary names what
@@ -57,20 +53,11 @@ fi
 
 # ── 0. WHICH remote is the base? ─────────────────────────────────────────────────────────────────
 # THE GH SIDE AND THE GIT SIDE MUST ANSWER ABOUT THE SAME REPOSITORY. `gh` follows
-# `gh repo set-default`; this script used to take the git side from a fixed candidate list
-# (origin/HEAD, origin/main, …). With ONE remote those agree, which is why it shipped. With TWO
-# they do not: a checkout whose work lives on a second remote while `origin` points elsewhere had
-# EVERY merged PR reported "MERGED BUT UNREACHABLE" — 18 false alarms in one field run, in capitals.
-# The PRs were not unreachable; they were in a different repo than the git side was asked about.
-#
-# That is not cosmetic. The sweep is a good check and it catches a real class (a stacked PR merged
-# into a dead base, never arriving on the default branch). An alarm that is wrong 18 times in a
-# LEGITIMATE setup is skipped by the third run — and then it is absent the day it is right. The
-# false-positive rate is what keeps a finding alive; the same argument the gate's own record makes.
-#
-# So: ask gh which repository is in play, find the remote whose URL points there, and prefer that
-# remote's refs. When it cannot be resolved, fall back to the old list and SAY SO — a base that
-# might be the wrong repository must never read like a verified one.
+# `gh repo set-default`, so: ask gh which repository is in play, find the remote whose URL points
+# there, and prefer that remote's refs. When it cannot be resolved, fall back to the fixed
+# candidate list (origin/HEAD, origin/main, …) and SAY SO — a base that might be the wrong
+# repository must never read like a verified one.
+# Why: docs/rationale/open-items.md § Eighteen false alarms: gh and git answered about different repositories
 BASE_REMOTE=""; GH_NWO=""; BASE_NOTE=""
 if [ "$GH_OK" = yes ] && [ "$GIT_OK" = yes ]; then
   GH_NWO="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"

--- a/.claude/skills/wai/scripts/run-log.sh
+++ b/.claude/skills/wai/scripts/run-log.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env sh
 # run-log.sh — one appended row per skill run: the suite's attendance record.
 #
-# Issue #11, measured in the field: a skill leaves a trace today ONLY if it files something — a gate
-# verdict, an issue. A security audit that finds nothing, a team run over eight issues and three
-# hours, a planning pass that comments on an existing issue: all ran, all vanished. THE RECORD
-# MEASURES SIDE EFFECTS, NOT WORK — and it is confident enough to be misread: counting issues by
-# skill showed 3 planning findings against 58 from pr-review, and a report concluded from that that
-# almost every PR was planned. The number was right; it measured issue creation, not value produced.
-# This file is the missing denominator. One row per run, written at hand-back, append-only like the
-# gate ledger: a run without a row is invisible work.
+# Without this file the record measures SIDE EFFECTS, not work: a skill leaves a trace only if it
+# files something. This file is the missing denominator. One row per run, written at hand-back,
+# append-only like the gate ledger: a run without a row is invisible work.
+# Why: docs/rationale/run-log.md § The record measured side effects, not work (issue #11)
 #
 # Deliberately NOT a second ledger to tag: the gate ledger's value comes from the human judging each
 # row, and asking for that twice would kill both. This is pure attendance — who ran, on what, with
@@ -39,11 +35,10 @@
 #        Appends to <repo-root>/docs/architecture/run-log.md ($RUN_LOG overrides the path — the
 #        same pattern as $MERGE_GATE_LEDGER on the gate ledger; outside a git repo, cwd-relative).
 #
-# WHAT COUNTS AS ONE RUN — defined here because undefined it was measured wrong (issue #29): rows
-# were written per HAND-BACK, so a turn that implemented three subjects logged one row and the
-# count undercounted by a factor nobody could reconstruct. The unit is one row per (skill, subject)
-# completed: a turn that hands back three subjects logs three rows; a re-run on the same subject
-# logs again (two rows for two runs is correct — the gate ledger already counts that way).
+# WHAT COUNTS AS ONE RUN: the unit is one row per (skill, subject) completed. A turn that hands
+# back three subjects logs three rows; a re-run on the same subject logs again (two rows for two
+# runs is correct — the gate ledger already counts that way).
+# Why: docs/rationale/run-log.md § Rows per hand-back undercounted runs (issue #29)
 
 set -u
 if [ -n "${ZSH_VERSION:-}" ]; then exec /bin/sh "$0" "$@"; fi

--- a/docs/rationale/backlog-scan.md
+++ b/docs/rationale/backlog-scan.md
@@ -1,0 +1,30 @@
+# `backlog-scan.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## Why a script and not the model reading the backlog
+
+The reason the proposal is emitted by a script and not by "the model reads the backlog": the
+frontier and the default order are a dependency computation, and a model re-deriving a topo order
+by eye on every run is exactly the brittle-prompt failure ADR-0002 exists to remove. Compute it
+once, in the script, and let step 2 refine a single source instead of inventing its own.
+
+## A mechanical fact must not wear a verdict's clothes
+
+A checklist-free issue can be perfectly workable and a checklist-heavy one can be noise — which is
+why the scan refuses to grade "actionable". Emitting an "actionable: no" verdict from a checkbox
+count is the same category error as a lint that fails a repo for tailoring: a mechanical signal
+wearing a semantic verdict's clothes. So the script emits the fact and names it a fact; the
+drop/keep judgment stays with the model.
+
+## Attendance: a run that files nothing vanishes
+
+Issue #11 found that the record measures side effects, not work — a team run that files nothing
+vanishes from the record. That is why the scan self-logs its own run-log row: it opens every
+wai-team run and maps 1:1 to that skill, so attendance is written by the script at scan time, not
+remembered at report time.

--- a/docs/rationale/catalog-variant.md
+++ b/docs/rationale/catalog-variant.md
@@ -1,0 +1,17 @@
+# `catalog-variant.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## One master, derived variants
+
+The suite offers the quality catalog in three sizes, and the obvious way to ship that — three
+hand-maintained files — is the failure mode this repo documents everywhere else: a SEC fix that
+lands in two copies out of three is a silent drift nobody notices, because a stale catalog reads
+exactly like a current one. So there is one master (`quality-attributes.baseline.md`), and the
+variants are derived from it mechanically; tests/run.sh regenerates and diffs the checked-in
+variant files, so they cannot drift from the master without CI going red.

--- a/docs/rationale/coordination-lint.md
+++ b/docs/rationale/coordination-lint.md
@@ -1,0 +1,16 @@
+# `coordination-lint.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## Wrong in the unsafe direction looks identical to working
+
+A config that is wrong in the SAFE direction (autonomy off) costs nothing. A config that is wrong
+in the UNSAFE direction — a narrowed exclusion floor, an allowlist that authorises too much, a
+webhook secret committed in the clear — costs everything, silently, and looks identical to a
+working one. So the config gets the same treatment as the merge gate: a script owns the mechanical
+checks, because "the model read the config and it looked fine" is not something anyone can audit.

--- a/docs/rationale/cross-issue-digest.md
+++ b/docs/rationale/cross-issue-digest.md
@@ -1,0 +1,19 @@
+# `cross-issue-digest.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## Why a re-read and not the model's memory
+
+A long run touches many issues in passing: it references #this from a comment on #that, it learns
+that #A actually depends on #B, it discovers a real problem on an issue it is not working. The
+landing rule says a genuine finding gets FILED — but the raw material for that decision is
+scattered across every issue the run brushed against, and asking a model to remember, at report
+time, every comment it made three hours ago on an issue outside the set is the please-remember
+pattern ADR-0002 retired. So a script re-reads the backlog for edits since the run's start
+timestamp, on issues outside the worked set, and hands back the candidates; the model only
+curates, and nothing is filed automatically.

--- a/docs/rationale/dep-cve-scan.md
+++ b/docs/rationale/dep-cve-scan.md
@@ -1,0 +1,33 @@
+# `dep-cve-scan.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The empty-output trap
+
+The security audit asks "are there known-vuln dependencies?" The trap it kept falling into:
+`npm audit 2>/dev/null` returning empty is INDISTINGUISHABLE from "0 CVEs" and "the scanner is
+not installed". A tool that printed nothing may never have run. A prose instruction to "report
+not measured if it didn't run" is the same fragile please-remember the suite moved off of — which
+is why a script now decides, deterministically, whether each scan ran, and emits `not_measured`,
+never a silent 0, when it did not.
+
+## The undici incident
+
+Field incident: undici CVE-2026-12151. undici — the engine behind Node's global fetch — is not an
+npm dependency; it ships bundled in the runtime's base image, so the dependency audit reporting 0
+for it was real and meaningless at once. The CVE was invisible to the dependency audit and caught
+only by the image scan. That incident is why the SCOPE caveat prints on every run: a clean
+lockfile result must never be read as a clean runtime, and a runtime-bundled CVE is fixed by a
+base-image bump, not a package update.
+
+## Why the scan self-logs
+
+Issue #11: the record measures side effects, not work — an audit that finds nothing vanishes,
+because it files nothing. Attendance is the fix: the CVE sweep marks a wai-security-audit run, so
+the script self-logs one run-log row with its summary state, and a clean audit still leaves a
+trace.

--- a/docs/rationale/gate-stats.md
+++ b/docs/rationale/gate-stats.md
@@ -1,0 +1,39 @@
+# `gate-stats.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The 0% that was 15%
+
+The first parser compared outcome tags LITERALLY: `outcome["NO-GO/ok"]`. Then a three-week field
+ledger arrived (issue #10) in which the human's vocabulary was finer than two letters — `fp, bug`,
+`ok, besser GO`, `ok, manual fix` — and none of it was `ok` or `fp` to a string comparison. Twenty
+of fifty-two judged NO-GO rows fell out of the statistic, unannounced, and the output read
+"false-positive rate: 0%". The true value was 15%. The zero was not a measurement; it was a parser
+artifact, sitting in the very line meant to prove the gate trustworthy. That is what bought the
+rule the script keeps: the tag is the first two characters, the free text after a comma is the
+human's and is preserved — and any tag the parser cannot place is counted and printed, because a
+statistic that drops rows must say so.
+
+## The cwd default that reported a false blank
+
+The default ledger path used to resolve from the cwd. That made a documented invocation report
+"no ledger" over a repo that had 28 rows — a false blank. The default is repo-relative now,
+matching merge-gate.sh, the writer this script reads.
+
+## Why setup outranks checks outranks domain
+
+The precedence setup > checks > domain in the mechanical cause classification matches how the
+field report counted: a row failing on environment AND domain is an environment problem first —
+the remedy the gate prints 55 times is "declare required checks".
+
+## Eleven besser-GO rows sat unread for three weeks
+
+`ok, besser GO` marks a block that was correct by the rules while the human says GO would have
+been fine — the most precise feedback a gate can get. Eleven of these sat unread in the field
+ledger while the gate went unchanged for three weeks; the calibration line in the report exists
+so that signal is surfaced instead of buried in free text.

--- a/docs/rationale/install-hook.md
+++ b/docs/rationale/install-hook.md
@@ -1,0 +1,17 @@
+# `install-hook.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The literal marker blocked a commit in the field
+
+The rule that the gap marker is assembled and never written as one contiguous string is not
+hypothetical caution: the literal, written out in a shipped file, blocked a human's commit in the
+field — the generated hook greps staged content for the marker, matched the suite's own source as
+if it were a real open exercise, and refused the commit. The same literal also made
+open-gap-check.sh unable to ever say "safe to plant" in any repo that carries `.claude/skills/`,
+because every marker-scanner treats the string as an open gap wherever it appears in the tree.

--- a/docs/rationale/invocation-log.md
+++ b/docs/rationale/invocation-log.md
@@ -1,0 +1,24 @@
+# `invocation-log.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The prompt-written tier was measured and had gaps (#29)
+
+This script was decided in issue #29 on 2026-08-18. The run log's two tiers were measured in the
+field: the script-written tier logged 9 of 9; every prompt-written tier had gaps —
+architecture-audit 0 rows with a committed report, learning-gap 0 rows with a ledger entry,
+implementation 4 of 5. Self-logging that depends on the model is not a measurement. The fix is
+the two artifacts the script's header names — this mechanical denominator with no outcome column,
+and run-log.md as the model-written numerator — never merged.
+
+## A crafted skill name forged denominator rows
+
+The skill name is the one field a row takes from the hook payload, and a name carrying '|' forged
+extra columns — a crafted skill name minted rows with a fake timestamp and skill, corrupting the
+very denominator this log exists to make trustworthy. Hence the table-safe sanitisation
+(run-log.sh's cell() shape) before the append.

--- a/docs/rationale/learning-gap-tests.md
+++ b/docs/rationale/learning-gap-tests.md
@@ -1,0 +1,27 @@
+# `tests/run.sh` (wai-learning-gap) — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The suite paid twice for shell gates before these rules existed
+
+These scripts are the ADR-0002 mechanics of a skill that had none, and the harness's two governing
+rules were not designed in the abstract: the suite had already paid, twice, for the two ways a
+shell gate ships broken. Once for a `case … esac` inside `$( )` — a syntax error in bash 3.2,
+which is what /bin/sh is on macOS, and which shellcheck passes — hence every case runs under both
+dash and bash 3.2. And once for a gate that had only ever been seen failing, which is not a
+validated gate — hence every script is exercised on its GO path (exit 0) as deliberately as on
+its NO path.
+
+## The marker that sat invisible in a linked worktree
+
+The worktree sweep exists because of a field incident (issue #13): the ledger is shared across
+every worktree but the trees are not, so a check that grepped only its own tree compared two
+sides with different reach — and a marker planted from a linked worktree sat invisible for two
+days while flow B booked it "expired". The test cases pin both halves of the fix: a marker in
+another worktree is reported as misplaced (not expired), and a clean multi-worktree repo is still
+a clear.

--- a/docs/rationale/ledger-lint.md
+++ b/docs/rationale/ledger-lint.md
@@ -1,0 +1,17 @@
+# `ledger-lint.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The same hole catalog-lint closed, one level down
+
+A ledger has ingest (the skill WRITES rows) and query (it READS boxes to choose a gap). It never
+had a lint — the same hole catalog-lint.sh was written to close, one level down. So an axis label
+could be a typo the box-weighting silently ignores, an enabled axis could carry no level, two gaps
+could be open at once, and a Socratic gap could record NO expected answer — fatal, because with
+nothing recorded the gap can never be marked solved and rides along invisibly. Nothing checked.
+This script is the check that closed that hole.

--- a/docs/rationale/ledger-locate.md
+++ b/docs/rationale/ledger-locate.md
@@ -1,0 +1,18 @@
+# `ledger-locate.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## A derived slug drifts, and the gate goes silent
+
+The consent gate is load-bearing, and it has one invisible failure mode the skill's own prose
+warns about: a slug is DERIVED (from the remote, or the folder), and derived things drift — the
+repo is transferred to an org, renamed, forked; the folder is moved. A naive path check then finds
+no ledger at the new slug and concludes "this human never opted in" — going silent, orphaning
+their Leitner state, and by the very design of the gate NOBODY is told. That failure mode is why
+the gate is a lookup and not a path check: what a ledger RECORDS about its repo (the remote URL,
+the owner/repo) does not drift when the path does.

--- a/docs/rationale/mine-issues.md
+++ b/docs/rationale/mine-issues.md
@@ -1,0 +1,34 @@
+# `mine-issues.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The backlog is evidence a cold read of the code misses
+
+wai-init writes a quality catalog. Left to a cold read of the code, it proposes the dimensions the
+code SHAPE suggests — and misses the ones the team has been feeling for months but that leave no
+structural trace: the label people keep reaching for, the word that recurs across a dozen bug
+titles, the theme half the closed PRs share. That history is evidence, and evidence a catalog
+author never sees is a catalog dimension never written. So this script surfaces it — as COUNTS the
+model then judges, never as a verdict.
+
+## An issue body is the most PII-dense text in a repo
+
+Stack traces with usernames, customer emails, tokens pasted in a hurry — an issue body is the most
+PII-dense text in a repo, and why the refusal to print one is the point, not a limitation. Mining
+bodies wholesale into a catalog proposal would launder that PII into a committed doc. That is why
+the script prints issue NUMBERS, never bodies; why bodies are read only behind `--bodies` and only
+to widen the TERM_DF corpus; and why every email-shaped token is redacted before it is ever
+tokenised.
+
+## Why there is no exit 3
+
+"You ran me in the wrong place" and "I could not reach GitHub" are different FACTS, but they are
+the same DECISION for the caller: do not trust the mining, fall back to code-only. The distinction
+belongs in the message, not the exit code — and the suite's precedent is settled:
+excluded-domains.sh and merge-gate.sh both map misuse to 2. A private fourth code makes every
+caller learn a per-script dialect.

--- a/docs/rationale/open-gap-check.md
+++ b/docs/rationale/open-gap-check.md
@@ -1,0 +1,55 @@
+# `open-gap-check.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## Two sides, because the ledger has no lock
+
+The skill's own prose says why the ledger alone is not enough: the ledger is a single unlocked
+file shared across every clone and worktree of a repo. Two concurrent sessions both read "no open
+row" and both plant — so the working TREE (`git grep` for the gap marker) is the side that
+actually catches a second gap, and the ledger is the side that catches a marker a human deleted
+without solving. You need both.
+
+## The exit code is not a bitmask
+
+A tempting design folds "which side is open" into the exit code (2 = ledger-side open). That is
+exactly the bug the merge gate exists to warn about: it steals the UNKNOWN code — the suite's
+universal "could not verify, fail closed" — and makes the check misreport which of its own states
+it is in. So the SIDE goes in stdout, where it is data, and 2 keeps its one meaning: something
+could not be read.
+
+## The detector used to contain its own marker
+
+This script used to grep for the literal marker string, which meant the literal was IN this file —
+so it matched itself, and it matched every other file that handles the marker as data (the hook
+installer, the test fixtures). Since `.claude/skills/**` is committed in every repo install.sh has
+touched, the result was that learning mode could NEVER plant a gap in a repo that vendors the
+suite: exit 1, "resolve the open gap first", and nothing to resolve. Assembling the pattern at run
+time is the fix that needs no path exclusions — and a blanket `:!.claude/skills/*` exclusion would
+have been wrong anyway, because this repo is itself a project someone may legitimately be
+learning on.
+
+## The sweep used to stop at its own worktree
+
+The ledger hangs off the repo and is shared across all worktrees; a working tree is not. This
+script used to grep only the tree it ran in, so the two sides it compares had different reach —
+and in the field (issue #13) that cost two days: a gap planted from a linked worktree was
+invisible in the main checkout, the check reported only the ledger row, and flow B's "no marker +
+no claim = expired" booked an exercise the human had never seen. "No marker HERE" and "no marker
+ANYWHERE" are different facts — which is why a marker found in ANOTHER tree is reported as
+misplaced (exit 1, its own line), never as expired, and an unreadable listed tree makes the
+verdict UNKNOWN rather than being silently counted as clear.
+
+## A green that named a side it never read
+
+The no-argument default used to guess the `temp/` fallback path instead of asking ledger-locate.sh.
+For a normal participant (whose ledger is under ~/.claude/learning/) the ledger side was therefore
+skipped entirely while the output still announced "tree and ledger both clear". A green that names
+a side it never read is the exact thing ADR-0002 forbids — and it is why the final verdict now
+says exactly which sides were read: "both clear" when one side was never located is the claim this
+script was caught making.

--- a/docs/rationale/open-items.md
+++ b/docs/rationale/open-items.md
@@ -1,0 +1,37 @@
+# `open-items.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## Self-recall under-reports, and MERGED is not arrived (issue #7)
+
+Issue #7, measured twice in the field: self-recall under-reports ~3× — a long session
+retrospected from memory reported 2 of 6 verified failures, and described one of the missed ones
+as handled. And "MERGED" is not "arrived": a four-commit batch landed on a branch whose PR was
+already merged; GitHub said MERGED, the default branch never saw it, and it was found a day later
+by accident. A footer the model writes from memory inherits exactly that bias, in the comfortable
+direction: an empty list reads as coverage. That is why the script emits and the model pastes.
+
+Each of the three rules in the script's header (an empty line names its derivation; a skipped
+class is named in the summary; per-line degradation) was a measured failure without it.
+
+The ADR-0002 boundary is stated up front in the script because a script that decided "what to do
+next" would be exactly the class this repo has deleted twice.
+
+## Eighteen false alarms: gh and git answered about different repositories
+
+This script used to take the git side's base from a fixed candidate list (origin/HEAD,
+origin/main, …) while `gh` followed `gh repo set-default`. With ONE remote those agree, which is
+why it shipped. With TWO they do not: a checkout whose work lives on a second remote while
+`origin` points elsewhere had EVERY merged PR reported "MERGED BUT UNREACHABLE" — 18 false alarms
+in one field run, in capitals. The PRs were not unreachable; they were in a different repo than
+the git side was asked about.
+
+That is not cosmetic. The sweep is a good check and it catches a real class (a stacked PR merged
+into a dead base, never arriving on the default branch). An alarm that is wrong 18 times in a
+LEGITIMATE setup is skipped by the third run — and then it is absent the day it is right. The
+false-positive rate is what keeps a finding alive; the same argument the gate's own record makes.

--- a/docs/rationale/retro-compliance.md
+++ b/docs/rationale/retro-compliance.md
@@ -1,0 +1,35 @@
+# `retro-compliance.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The record measured side effects, not work
+
+Issue #10, Part B, measured in the field: a skill left a trace ONLY if it filed something, so the
+record measured the side effects of work, not the work. The run log (issue #11) is the fix — one
+appended row per run — and this script exists because the run log's second writer tier is prose:
+a SKILL.md sentence that nothing verifies. Crossing the run log against the gate ledger and the
+merge history is where that prompt-contract weakness, pointed at the suite itself, becomes
+visible instead of comfortable.
+
+## The merge-commit denominator inverted the metric
+
+`git log --merges` was the only enumerator of merged PRs — offline and deterministic, but it reads
+merge COMMITS, and a squash- or rebase-merged PR leaves none. That inverted the metric's purpose
+on any repo that squash-merges. On this repo PRs #1–#6 were merge-committed and everything since
+#15 was squashed, so the live traced share (5/5 = 100%) covered only the era that PREDATES the
+metric, and the very gap that motivated it (#15/#16 merged without gate verdicts) was invisible.
+A denominator that silently excludes the population it was built to measure is worse than no
+denominator. (#24) That is why the script now prefers `gh pr list --state merged` — which counts
+a squash merge exactly like a merge commit — and names the degradation whenever it has to fall
+back to merge commits.
+
+## A 0% that was really 15%
+
+The principle "every metric needs a counter-reader" was bought in the field: a 0% that was really
+15% once shipped inside the very line meant to prove trustworthiness. That is why every rate this
+script prints carries its raw counts beside it.

--- a/docs/rationale/run-log.md
+++ b/docs/rationale/run-log.md
@@ -1,0 +1,24 @@
+# `run-log.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The record measured side effects, not work (issue #11)
+
+Issue #11, measured in the field: before this file, a skill left a trace only if it FILED
+something — a gate verdict, an issue. A security audit that finds nothing, a team run over eight
+issues and three hours, a planning pass that comments on an existing issue: all ran, all
+vanished. The record measured side effects, not work — and it was confident enough to be misread:
+counting issues by skill showed 3 planning findings against 58 from pr-review, and a report
+concluded from that that almost every PR was planned. The number was right; it measured issue
+creation, not value produced. This file is the missing denominator.
+
+## Rows per hand-back undercounted runs (issue #29)
+
+"What counts as one run" is defined in the script's header because undefined it was measured
+wrong (issue #29): rows were written per HAND-BACK, so a turn that implemented three subjects
+logged one row and the count undercounted by a factor nobody could reconstruct.

--- a/docs/rationale/verify-gap-breaks.md
+++ b/docs/rationale/verify-gap-breaks.md
@@ -1,0 +1,15 @@
+# `verify-gap-breaks.sh` — why it is written this way
+
+> The narrative that used to live in this script's long comment blocks. Moved here on
+> 2026-08-19: a comment is billed to the context window every time a model opens the file, and it
+> does — when a skill says "run it", when something breaks, when anyone edits the check. The
+> operative rule stayed in the script, where an editor sees it; the incident that bought the rule
+> is here, still citable and no longer billed per run. **Nothing was deleted.**
+
+
+## The red-probe replaced a prose promise
+
+The skill used to assert "the gap must fail visibly" in prose and hope the model checked. "The
+model checked" is not auditable. The script is: it runs the project's own test command and reads
+the exit code, so the promise that a planted gap goes red is verified mechanically instead of
+being trusted to the model's diligence.


### PR DESCRIPTION
## What

Extends #42's rationale split to the rest of the shipped scripts under `.claude/skills/*/scripts/`. Seventeen scripts move their incidents, field measurements and rejected-alternative essays into `docs/rationale/<script>.md` (same preamble and `# Why: … § …` pointer convention as #42); seven more (`rank-pr-candidates`, `shuffle-ingredients`, `contract-completeness`, `handoff-lint`, `attack-path-lint`, `post-merge-verify`, `autonomous-merge-report`) were inspected and deliberately left untouched — their comments are entirely operative, so moving anything would move a rule.

## Why

Same argument #42 accepted and `docs/rationale/README.md` records: a comment is free on disk and billed to a context window every time a model opens the script — and models do open them. The policy line stays exactly where #42 drew it: `Usage:`, `#   exit N` contracts (contract-lint check 3 machine-reads them), rule statements and at-the-line warnings stay in the script; anything past-tense moves.

## Plan

Planned and approved in-session: fan-out per skill directory, policy-conform classification (when in doubt, it stays), mechanical proof that no code line changed.

## Verification

- Every edited script: `sh -n` clean; **non-comment lines byte-identical to `main`** (`diff` of comment-stripped old/new prints nothing) — behavior provably unchanged.
- `contract-lint.sh` OK · `catalog-lint.sh` OK · `tests/numbers-lint.sh` green · `tests/lang-guard.sh` green · `tests/run.sh` **181/0**.
- Every `# Why:` pointer heading matches a `##` heading in its rationale file verbatim.
- No backticked catalog-ID citations entered `docs/` (checked against catalog-lint's pattern; CVE ids written unbackticked deliberately).

## The honest number

Comment mass in the seventeen: 76,272 → 69,147 bytes (**≈7.1 KB, ~1.8k tokens net**). Less than the raw comment volume suggests, because most of what remains is rules by the policy's own table. Cutting deeper is a policy change (moving live rules/contracts out of the scripts), not a further application of this one — deliberately not done here.

## Not fixed here / follow-up candidates

- The root-level test harnesses (`tests/run.sh`, `tests/scripts.sh`, …) carry the same narrative style but sit outside the `.claude/**` scope of this pass.
- `merge-gate.sh` and `excluded-domains.sh` still hold ~30 KB of comments post-#42; they are the deciding scripts, and their retained mass is the policy working as intended.

## Back-compat

No API surface, no behavior: code lines are byte-identical to `main` (proven above). `.claude/skills/**` is EX-GUARD — this PR is the human's to merge, as always.

▶ Recommended next: **wai-pr-review** on this PR (no new tests needed — the existing suite guards exactly what this change could break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)