### PR TITLE
chore(release): pin install examples to v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ sits inside a checkout, it installs *from that checkout* — so the tree you rev
 you get, not whatever the remote's default branch holds.
 
 ```bash
-git clone --depth 1 --branch v0.3.0 https://github.com/woldinius/wai-skill-suite.git /tmp/wai
+git clone --depth 1 --branch v0.3.1 https://github.com/woldinius/wai-skill-suite.git /tmp/wai
 sh /tmp/wai/install.sh            # installs into the current directory
 rm -rf /tmp/wai
 ```
@@ -230,7 +230,7 @@ same version. (An earlier README once pinned to a tag before that tag existed �
 `tests/numbers-lint.sh` now checks every version reference here against `git tag`.)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/woldinius/wai-skill-suite/v0.3.0/install.sh | SKILLS_REF=v0.3.0 sh
+curl -fsSL https://raw.githubusercontent.com/woldinius/wai-skill-suite/v0.3.1/install.sh | SKILLS_REF=v0.3.1 sh
 ```
 
 What the script does — and deliberately does **not** do:

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@
 # Usage (run in your project root) — from a checkout you have read:
 #   sh install.sh [target-project-dir]
 # or, pinned to a release (tests/numbers-lint.sh checks this tag exists):
-#   curl -fsSL https://raw.githubusercontent.com/woldinius/wai-skill-suite/v0.3.0/install.sh | SKILLS_REF=v0.3.0 sh
+#   curl -fsSL https://raw.githubusercontent.com/woldinius/wai-skill-suite/v0.3.1/install.sh | SKILLS_REF=v0.3.1 sh
 # or, unpinned (latest main):
 #   curl -fsSL https://raw.githubusercontent.com/woldinius/wai-skill-suite/main/install.sh | sh
 #


### PR DESCRIPTION
Follow-up to #47, held until the tag existed: install.sh and the README move their pinned examples from `v0.3.0` to `v0.3.1` (cut on b5833a5). Dated `v0.3.0` mentions in records stay. This PR also collects its own gate rows before merge, per the ledger-home rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)