### PR TITLE
feat(implementation): a step that actually runs something — the evidence gate, a bounded fix loop, a ratchet (obra/superpowers)

### DIFF
--- a/.claude/skills/wai-implementation/SKILL.md
+++ b/.claude/skills/wai-implementation/SKILL.md
@@ -53,6 +53,13 @@ truth** (`PAY-*`; tokens are digital goods → iOS StoreKit / Android Play Billi
    goes red on exactly this bug** (a failing test, a curl, a CLI invocation — run it and keep
    its output). No reproducible red, no fix — the red command later proves the fix and becomes
    the regression test. Then find the root cause, don't just patch the symptom.
+   **Write the hypothesis down before you change a line**, change **one variable at a time**, and
+   **revert a failed attempt before trying the next** (the snapshot pattern,
+   `references/agent-git-protocol.md` §*The snapshot pattern* in the `wai` skill — `cp` aside,
+   never `git restore`). **After three failed fixes, stop.** Three misses means the *hypothesis
+   class* is wrong, not that the fourth patch is closer. Hand back what you tried, what each
+   attempt ruled out, and the red command — the human decides whether the architecture is the
+   bug. A fourth patch on a wrong model is how a symptom fix ships.
    **If the task is remediating a CVE, triage by its SOURCE before reaching for a package
    manager.** Lockfile dependency → update or override it. **OS package or a library bundled in
    the runtime** (e.g. Node's `undici` behind `fetch` — not an npm dependency, it ships inside
@@ -61,7 +68,7 @@ truth** (`PAY-*`; tokens are digital goods → iOS StoreKit / Android Play Billi
    the base image.
    **If the task is a GitHub Issue** (`#N`, a URL, or "the issue about X"), read it first with
    `gh issue view <N> --comments` and use it as the task source; note the issue number to wire
-   `Closes #N` into the PR (step 7).
+   `Closes #N` into the PR (step 8).
 
 2. **Load context** — review relevant code and git history. **Check `docs/`**,
    especially the contract domains **API, User Management, Login, Security, Token,
@@ -89,28 +96,60 @@ truth** (`PAY-*`; tokens are digital goods → iOS StoreKit / Android Play Billi
      implementation. For a **high blast radius**, touching a **contract domain**
      (API, User Management, Login, Security, Token, Billing) or **ambiguity of
      intent** → stop after the plan and wait for the "go".
+   - **The gate is re-evaluated whenever implementation discovers what planning did not.** If the
+     change turns out to touch a **contract domain** (API, User Management, Login, Security,
+     Token, Billing), reach a **surface the plan did not name**, or carry a **materially larger
+     blast radius** → **stop where you are and re-gate**, even mid-file. Say what you found and
+     what it changes. **The ratchet only turns up:** discovering the change is *simpler* than
+     planned never removes a gate that already applied, and "I'm nearly done" is not a reason to
+     skip one. This is distinct from the plan-delta check (step 2), which covers what the *human*
+     changed — this covers what the *code* revealed.
 
 4. **Implement** — following repo conventions and the central quality catalog
    (`docs/architecture/quality-attributes.md`), per affected layer its concerns.
 
-5. **Self-Review** — run a lightweight check of your own diff against the catalog
-   (short form of wai-pr-review): no keys in the code (`SEC-3`), model output
-   validated (`AI-3`), idempotency on expensive/mutating paths (`RES-3`), cost impact
-   (`AI-9`/`OBS-3`), backward compatibility (`API-1`). For **client** work: no secrets in the
+5. **Self-Review — start from the diff, not from what you meant.** Read
+   `git diff <base>...HEAD` in full **first**, and review the code that is actually there
+   against the plan and the catalog — not your recollection of what you intended to write.
+   Then the lightweight checklist (short form of wai-pr-review): no keys in the code
+   (`SEC-3`), model output validated (`AI-3`), idempotency on expensive/mutating paths
+   (`RES-3`), cost impact (`AI-9`/`OBS-3`), backward compatibility (`API-1`). For **client** work: no secrets in the
    binary/bundle (`CLIENT-1`), attestation wired (`CLIENT-2`). For **token** work: server-side
    verification + idempotent credit/debit (`PAY-2`/`PAY-3`/`PAY-4`), digital-goods rule (`PAY-8`).
+   Close with one line naming **the strongest reason a reviewer would reject this** — if you
+   cannot name one, you reviewed your intent, not your diff. This is only the short form; the
+   fresh-context review is `wai-pr-review`'s, and it is **not** made optional by this one having
+   run.
 
-6. **Update `docs/`** — when a contract or architecture aspect has changed,
+6. **Prove it — no "done" without fresh output.** Name the one command that proves this change
+   works, run it **now** (not from memory of a run earlier in the session), and keep its output.
+   - **Bug:** re-run the **exact red command from step 1**. It must go **green**. That
+     transition — red before, green after — is the proof, and it is what the regression test
+     locks in place.
+   - **Feature / refactor:** build, typecheck and lint clean, plus the narrowest command that
+     actually exercises the new path (a test, a `curl`, a CLI invocation).
+   - Paste the command and its verdict into the PR body under **Verification** (step 8).
+   - **If no command can prove it** — infra-only, a docs-shaped change, a path that needs a
+     device or a store sandbox — say so explicitly: *"not verified locally: <why>"*, and hand
+     the gap to `wai-testing`. **Fail-open is allowed here; silence is not.**
+   - Banned as a completion claim: *"should work"*, *"probably fixes it"*, *"looks right"*.
+     Those are predictions, not evidence. The merge gate is fail-closed for exactly this reason
+     ([ADR-0002](https://github.com/woldinius/wai-skill-suite/blob/main/docs/adr/0002-mechanics-in-scripts-judgment-in-prompts.md):
+     *"the model checked" is not a thing anyone can audit*) — and `wai-testing`'s counterproof
+     rule is the same rule one layer down: green proves the test *ran*, not that it *checks*.
+
+7. **Update `docs/`** — when a contract or architecture aspect has changed,
    deliver the docs change as a **visible proposal** (especially API/OpenAPI, User
    Management, Login, Security, Token, Billing). Don't rewrite silently.
 
-7. **Commit, open the PR, and hand off** — Verify the branch first (`git branch
+8. **Commit, open the PR, and hand off** — Verify the branch first (`git branch
    --show-current` — never commit on `main`), then commit the change atomically
    (Conventional Commits + `Co-Authored-By` trailer), then **open the PR** with `gh pr create`
-   (what/why, link to the plan, catalog IDs, API back-compat statement) — or update it if one
-   already exists; never touch `main`. **If an issue drove the work**, add `Closes #N` to the PR
-   body (same-repo only — for a cross-repo issue use `owner/repo#N` and close manually); skip
-   cleanly when there's no issue.
+   (what/why, link to the plan, catalog IDs, API back-compat statement, and the
+   **Verification** block from step 6 — the command and its real output, or the named reason
+   there is none) — or update it if one already exists; never touch `main`. **If an issue drove
+   the work**, add `Closes #N` to the PR body (same-repo only — for a cross-repo issue use
+   `owner/repo#N` and close manually); skip cleanly when there's no issue.
    **What the self-review (step 5) surfaced but this PR does not fix** — a pre-existing weakness
    you routed around, a follow-up the change makes obvious — is either **deliberately rejected
    with a reason in the PR body** or **filed as an issue** (`issues-protocol.md` §*Where a
@@ -127,7 +166,7 @@ truth** (`PAY-*`; tokens are digital goods → iOS StoreKit / Android Play Billi
    order: the script derives (exit 0 = emitted; exit 2 = nothing derivable — then say `not checked`
    yourself), the model recommends.
 
-8. **Learning gap — the last action, and only when you hand back to the human.** Applies only if
+9. **Learning gap — the last action, and only when you hand back to the human.** Applies only if
    **this** human has a personal learning ledger (`~/.claude/learning/<repo-slug>/ledger.md`, or
    the `temp/learning/` fallback). **No ledger → skip silently and create nothing**: learning
    mode is a per-developer opt-in, never a repo-wide switch (git protocol §*Personal state never
@@ -259,6 +298,8 @@ specific to *this* skill:
 ## Principles
 
 - **Think first, then build** — the plan including risk/ambiguity/blast radius is mandatory.
+- **Prove it, don't predict it** — "done" is a command that ran and an output you kept, never a
+  forecast. Where nothing can be run, the gap is named out loud, not passed over.
 - **Platform thinking** — does the change pull app-specific special logic into the shared
   core or does it violate tenant isolation? If so: name it.
 - **Keep docs consistent** — a contract change without a `docs/` update is unfinished.
@@ -274,10 +315,17 @@ This skill is the **implementation** stage in the lifecycle plan → implement �
   seams** (see *Tests*).
 - **wai-pr-review** — the full review stage; the self-review here (step 5) is only the short
   form for your own diff before handover.
-- **wai-learning-gap** — the **last action of the turn** (step 8), and **only** if *this* human
+- **wai-learning-gap** — the **last action of the turn** (step 9), and **only** if *this* human
   has a personal ledger. `CLAUDE.md` never activates learning mode. No ledger → skip silently
   and create nothing.
 - **wai** — the suite router/overview.
 - Shared source of truth: `docs/architecture/quality-attributes.md` (testing strategy:
   `docs/architecture/testing-strategy.md`; contract rules: `references/contract-protocol.md`
   (in the `wai` skill)).
+
+*Provenance: the evidence gate (step 6), the three-strikes bound (step 1), the ratchet (step 3)
+and the diff-first self-review (step 5) are adopted from
+[obra/superpowers](https://github.com/obra/superpowers) (MIT) — what was taken, and the two
+things deliberately not taken, are recorded in
+[REFERENCES.md](https://github.com/woldinius/wai-skill-suite/blob/main/REFERENCES.md). An
+arbitrary-looking rule is a rule the next person deletes.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ Notable changes to the wAI skill suite. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are git tags, and every claim here is
 checkable against the tagged tree — `tests/numbers-lint.sh` keeps the measurable ones honest.
 
+## [Unreleased]
+
+### Changed
+
+- **`wai-implementation` gains a step that actually runs something — plus a bounded fix loop, a
+  ratchet and a real diff read.** Read against
+  [obra/superpowers](https://github.com/obra/superpowers) (MIT), the suite's default doer had four
+  places where it could hand back finished-looking work with nothing behind it. **A new step 6,
+  *Prove it*:** name the one command that proves the change, run it *now*, and paste it and its
+  output into the PR under **Verification** — and for a bug, re-run step 1's red command and see
+  it go **green**. Nothing in the skill had ever *executed* anything: step 1 built a red command
+  that no later step re-ran, step 5 read the diff against the catalog, step 7 opened the PR. That
+  is [ADR-0002](docs/adr/0002-mechanics-in-scripts-judgment-in-prompts.md)'s own failure shape —
+  *"the model checked" is not a thing anyone can audit* — sitting unnoticed at home. Where no
+  command can prove it, the skill must now *say so* (`"not verified locally: <why>"`): fail-open
+  is allowed, silence is not. **Step 1** bounds the bug fix loop — hypothesis written before the
+  first edit, one variable at a time, revert before retry, and **stop after three** rather than
+  stacking a fourth patch on a wrong hypothesis class. **Step 3**'s stop condition now re-fires on
+  what the *code* reveals mid-implementation (the step 2 delta check only ever covered what the
+  *human* changed after planning) and **ratchets one way only**. **Step 5** starts from a full
+  `git diff <base>...HEAD` read and closes by naming the strongest reason a reviewer would reject
+  the change. Steps renumbered 6 → 7 → 8 → 9 with every cross-reference updated; no other skill
+  referenced these numbers. The source, and the two borrows deliberately **rejected** — the TDD
+  iron law (it conflicts with `wai-testing` owning tests) and the sub-500-word budget (that is
+  **K8**/**Q5**, and it needs its own ADR with the measurement attached) — are recorded in
+  [REFERENCES.md](REFERENCES.md), in the same commit, per that file's own rule.
+
 ## [0.3.1] — 2026-08-19
 
 ### Changed

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -108,6 +108,40 @@ of the design. An earlier draft claim ("the verdict is deterministic *nowhere el
 **rejected** during the audit as an unfalsifiable negative — the exact claim class the
 publication rule exists for.
 
+### obra/superpowers
+<https://github.com/obra/superpowers> (MIT)
+**2026-08-20 · partially adopted**
+
+A software-development methodology shipped as composable skills. Read against
+`wai-implementation`, it is strong on the one axis this suite is thinnest on: **evidence and
+process discipline *during* the build**, where the suite had invested almost everything in
+judgment *before* it. The four primitives below each closed a place where `wai-implementation`
+could hand back finished-looking work with nothing behind it.
+
+| Source skill | What it became here |
+|---|---|
+| `verification-before-completion` — *"no completion claims without fresh verification evidence"* | **step 6, *Prove it*** — name the command, run it now, paste it and its output into the PR. For a bug, step 1's red command must be re-run **green**. Until this, nothing in the skill ever *ran* anything: step 1 built a red command that no later step re-ran, step 5 read the diff against the catalog, step 7 opened the PR. That is [ADR-0002](docs/adr/0002-mechanics-in-scripts-judgment-in-prompts.md)'s own failure shape — *"the model checked" is not a thing anyone can audit* — sitting unnoticed in the suite's default doer |
+| `systematic-debugging` — the three-strikes rule | the bug branch of **step 1** now bounds its fix loop: hypothesis written before the first edit, one variable at a time, a failed attempt reverted before the next (the snapshot pattern), and **stop after three** — handing back what each attempt ruled out instead of stacking a fourth patch on a wrong model |
+| `brainstorming` — *"hidden complexity upgrades the path; nothing downgrades mid-task"* | **step 3**'s stop condition **re-fires on discovery** and ratchets one way only. The gap: the plan-delta check (step 2) covered what the *human* changed after planning, and nothing at all covered what the *code* revealed mid-implementation — a contract domain reached after the gate had already said proceed |
+| `requesting-code-review` — crafted context beats remembered context | **step 5** now starts from a full read of `git diff <base>...HEAD` and closes by naming the strongest reason a reviewer would reject the change. It had said "check your own diff" without ever requiring the diff be read — which is how a self-review becomes a checklist run against intent |
+
+**Rejected — with the reason, so it is not asked a third time:**
+
+- **The TDD iron law** (`test-driven-development`: no production code before a failing test).
+  Incompatible with a split this suite made deliberately — `wai-testing` owns tests,
+  `wai-implementation` only *notes* the needs, and the strategy bans speculative unit tests in
+  favour of end-to-end-testable functions. The two places test-first genuinely pays are already
+  kept: *bug → build the red first*, and the mid-implementation invocation for **foundational
+  seams**. Adopting the law wholesale would buy duplication, not coverage.
+- **The word budget** (`writing-skills`: frequently-loaded skills under ~500 words, detail
+  displaced into `references/`). Correct on the merits, and already on this repo's own record as
+  criticism **K8** and open question **Q5** (context cost per run, unmeasured). Deferred on
+  purpose: it is a *suite-wide* convention — all twelve skills carry the same Platform-context
+  and Affected-surfaces sections, and `wai-init` generates its catalog variants against them. One
+  skill cut in isolation buys the inconsistency **without** the measurement, so it belongs in its
+  own ADR with Q5's numbers attached. Recorded here rather than in a backlog because the negative
+  result is the expensive half.
+
 ### mattpocock/skills
 <https://github.com/mattpocock/skills> (MIT)
 **2026-07-09 · partially adopted**

--- a/docs/architecture/run-log.md
+++ b/docs/architecture/run-log.md
@@ -47,3 +47,4 @@ a suite update must never touch this file (the same never-eaten guarantee as the
 | 2026-08-19T20:02Z | wai-pr-review | PR #46 | NO-GO |
 | 2026-08-19T20:31Z | wai-pr-review | PR #47 | NO-GO |
 | 2026-08-19T20:32Z | wai-pr-review | PR #47 | GO |
+| 2026-08-20T05:16Z | wai-implementation | obra/superpowers borrow — evidence gate, three-strikes, ratchet, diff-first review | four rules landed in wai-implementation with attribution in REFERENCES.md; draft PR #50, EX-GUARD so the human merges |

--- a/docs/architecture/run-log.md
+++ b/docs/architecture/run-log.md
@@ -48,3 +48,4 @@ a suite update must never touch this file (the same never-eaten guarantee as the
 | 2026-08-19T20:31Z | wai-pr-review | PR #47 | NO-GO |
 | 2026-08-19T20:32Z | wai-pr-review | PR #47 | GO |
 | 2026-08-20T05:16Z | wai-implementation | obra/superpowers borrow — evidence gate, three-strikes, ratchet, diff-first review | four rules landed in wai-implementation with attribution in REFERENCES.md; draft PR #50, EX-GUARD so the human merges |
+| 2026-08-20T21:31Z | wai-pr-review | PR #50 | NO-GO |


### PR DESCRIPTION
## What & why

Read `wai-implementation` against [obra/superpowers](https://github.com/obra/superpowers) (MIT).
The suite invests almost everything in **judgment before the build**; superpowers is strong on the
axis this skill was thinnest on — **evidence and process discipline during it**. Four holes came
out of that comparison, each a place where the default doer could hand back finished-looking work
with nothing behind it.

| Change | What it closes |
|---|---|
| **New step 6, _Prove it_** | Nothing in the skill ever *ran* anything. Step 1 built a red command that **no later step re-ran**; step 5 read the diff against the catalog; step 7 opened the PR. That is [ADR-0002](docs/adr/0002-mechanics-in-scripts-judgment-in-prompts.md)'s own failure shape — *"the model checked" is not a thing anyone can audit* — sitting unnoticed at home. Now: name the command, run it, paste it and its output into the PR. For a bug, step 1's red command must be re-run **green**. Where nothing can prove it, the skill must *say so* (`"not verified locally: <why>"`) — fail-open is allowed, silence is not. |
| **Step 1 — three-strikes bound** | "Find the root cause" bounded nothing, so a missed fix just became another fix. Now: hypothesis written before the first edit, one variable at a time, revert before retry, and **stop after three** — three misses means the *hypothesis class* is wrong, not that the fourth patch is closer. |
| **Step 3 — the ratchet** | The stop condition fired **once**, against the plan. Step 2's delta check covered what the *human* changed after planning; **nothing covered what the _code_ revealed** — a contract domain reached two files in, after the gate had already said proceed. Now it re-fires on discovery, and turns one way only. |
| **Step 5 — read the diff** | It said "check your own diff" without requiring the diff be *read*, which is how a self-review becomes a checklist run against remembered intent. Now it starts from a full `git diff <base>...HEAD` and closes by naming the strongest reason a reviewer would reject the change. |

Steps renumbered 6 → 7 → 8 → 9, every internal cross-reference updated. No other skill referenced
these numbers (checked across all thirteen).

**Attribution** — `REFERENCES.md` carries the source **in the same commit**, per that file's own
rule, including the two borrows deliberately **rejected**, because the negative result is the
expensive half:

- **The TDD iron law** — conflicts with a split this suite made on purpose: `wai-testing` owns
  tests, implementation only *notes* the needs. The two places test-first genuinely pays are
  already kept (bug → red first; foundational seams).
- **The sub-500-word budget** — correct on the merits, and already on record as **K8** / **Q5**.
  It is a *suite-wide* convention across all twelve skills plus `wai-init`'s generated variants,
  so one skill cut in isolation buys the inconsistency **without** the measurement. Own ADR, with
  Q5's numbers attached.

Plan: `~/.claude/plans/read-the-skill-users-benwol-git-wai-skil-lexical-riddle.md` (local).

## Verification

Run on this branch, output kept — the counterproof this repo demands, including seeing `release-lint`
go **red before** the CHANGELOG entry existed and **green after**:

```
$ sh tests/release-lint.sh            # skills changed, CHANGELOG entry NOT yet added
  STALE 1 file(s) under .claude/skills/ changed since v0.3.1, and CHANGELOG.md declares
        nothing newer — an unreleased change to the tree a user EXECUTES needs an
        '## [Unreleased]' section (or the next version's)
release-lint: 1 disagreement(s) between this tree and v0.3.1.
EXIT=1                                # RED, as intended

$ sh tests/release-lint.sh            # CHANGELOG entry added, amended into the same commit
release-lint: the tree agrees with its newest tag (v0.3.1).
EXIT=0

$ sh tests/run.sh
181 passed, 0 failed
EXIT=0
  (includes "every SKILL.md is under 5000 words" — this file is 3192,
   and "no SKILL.md points at a reference that does not exist")

$ sh tests/lang-guard.sh
lang-guard: no German outside the three files that document it.
EXIT=0

$ sh tests/numbers-lint.sh
numbers-lint: every measurable claim matches its measurement
              (baseline 87/513, readers 9, runs 8, scripts 28, ledger 42/7).
EXIT=0
```

```
$ gh pr checks 50            # required check on the pushed branch
ci   pass   42s
```

**Merge gate — the deterministic classification, obeyed rather than re-derived:**

```
$ sh .claude/skills/wai/scripts/excluded-domains.sh --files … --diff …
  x EX-GUARD  touches the suite's own guardrails (a human merges these, always):
              .claude/skills/wai-implementation/SKILL.md
EXCLUDED-DOMAINS: EX-GUARD
VERDICT: EXCLUDED — a human owns this change; do not agent-merge or act on it autonomously.
EXIT=1
```

Opened as **draft** accordingly: `EX-GUARD`, plus the blast-radius clause in
`agent-git-protocol.md` §*Pull request* — this is the daily-use default doer, and it ships into
every repo that installs the suite. Not merged, no auto-merge armed, no approval. Mark ready when
you are satisfied.

## Self-review — the strongest reasons to reject this

Named per the rule this PR itself adds:

1. **The new step 6 sits _after_ step 5, so the self-review reads a diff that has not yet been
   proven to run.** Arguably *Prove it* belongs before *Self-Review* — you would rather discover
   the thing is broken before spending a careful read on it. The approved plan fixed this order
   and I kept it, but it is the first thing I would challenge, and reordering is a one-line move.
2. **This adds ~61 lines of prose to a skill whose prose is criticism K8**, while explicitly
   deferring the word-budget fix to a later ADR. Defensible (the deferral has a stated reason and
   a measurement gate) but it is, plainly, more words in the file that is already too long.
3. **`ADR-0002` is linked by absolute GitHub URL** — a first for a `SKILL.md`. Rationale: the skill
   is installed into *other* repos where a relative `docs/adr/` path resolves to nothing, which is
   the precise failure ADR-0002 describes (telling a model to look up something that is not there).
   Still, it is a new convention introduced without a suite-wide decision.

## Back-compat

No script, exit code or interface changed — prose only, in one `SKILL.md`, plus two docs files.
`catalog-lint`, `merge-gate` and the ledger format are untouched. Nothing regenerates from this
file, and the three catalog variants still match their checked-in copies (asserted in `run.sh`).
