### PR TITLE
docs(references): name the three lanes superpowers covers and this suite does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ checkable against the tagged tree — `tests/numbers-lint.sh` keeps the measurab
 
 ## [Unreleased]
 
+### Changed
+
+- **`REFERENCES.md` names the three lanes `obra/superpowers` covers and this suite does not** —
+  as pointers, not plans. Read in full (all 14 skills) rather than only against
+  `wai-implementation`: **`writing-skills`** supplies a method for testing what a *prompt* does,
+  which is the gap `docs/learnings/empirical-test-plan.md` already states in its first line
+  ("specification-verified, not behaviour-verified") and which **Q2** and **Q4** have been waiting
+  on; **`receiving-code-review`** owns the end of a finding this suite never wrote down — verify
+  before implementing, clarify the set before starting, push back with reasoning — which matters
+  more here because the reviewer is often an agent; **`using-git-worktrees`** owns a lifecycle
+  four of this repo's own scripts sweep but no skill creates or cleans, and that cost a real red
+  on 2026-08-20 when stale registrations fail-closed `open-gap-check` at exit 2. Also recorded: a
+  caution that `finishing-a-development-branch` documents a local-merge path
+  `agent-git-protocol.md` forbids, so the two suites are not blindly installable together — and a
+  correction that only the *lesser* half of `requesting-code-review` was ever adopted, since
+  `wai-pr-review` still reviews in the same session as the work.
+
+
 ### Added
 
 - **Arrival is part of done** (#51). "Merged" used to mean "the forge said MERGED" — and a stacked

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -110,7 +110,8 @@ publication rule exists for.
 
 ### obra/superpowers
 <https://github.com/obra/superpowers> (MIT)
-**2026-08-20 · partially adopted**
+**2026-08-20 · partially adopted** · **2026-08-30 · re-read in full (14 skills); the three lanes
+it covers and this suite does not are named below, as pointers rather than plans**
 
 A software-development methodology shipped as composable skills. Read against
 `wai-implementation`, it is strong on the one axis this suite is thinnest on: **evidence and
@@ -141,6 +142,56 @@ could hand back finished-looking work with nothing behind it.
   skill cut in isolation buys the inconsistency **without** the measurement, so it belongs in its
   own ADR with Q5's numbers attached. Recorded here rather than in a backlog because the negative
   result is the expensive half.
+
+**Not adopted — because the gap is ours, not theirs.** Three lanes superpowers covers that this
+suite does not cover *at all*. They are listed as **pointers, not plans**: nothing here is
+scheduled, and a reader who needs one of them today is better served by going and reading the
+source than by waiting for a wAI version of it.
+
+- **`writing-skills` — testing what a prompt actually does.** This suite tests the two scripts that
+  own the verdict with 184 cases on two shells, and tests its **thirteen prompts with nothing**.
+  That is not a suspicion; it is written down in this repo already:
+  [`docs/learnings/empirical-test-plan.md`](docs/learnings/empirical-test-plan.md) opens with
+  *"everything built in this session is specification-verified, not behaviour-verified."*
+  superpowers supplies the missing **method** — write the failing scenario first, watch an agent
+  violate the rule *without* the skill, then write minimal guidance against that observed failure;
+  micro-test behaviour-shaping rules at 5+ repetitions against a no-guidance control. That is a
+  usable instrument for **Q2** (does the model *run* the gate or check from memory?) and **Q4**
+  (are the three lenses different, or decoration?), both of which have stayed open for lack of a
+  method rather than lack of will. The irony is worth naming: [ADR-0002](docs/adr/0002-mechanics-in-scripts-judgment-in-prompts.md)
+  moves mechanics into scripts *because a rule in a prompt fails silently* — and then the suite
+  tests only the scripts.
+- **`receiving-code-review` — the other end of a finding.** This suite is thorough about
+  *producing* findings (`wai-pr-review`, both audits) and about *where a finding lands*
+  (`issues-protocol.md`: fixed, rejected, or filed — no fourth outcome). It says nothing about how
+  to **receive** one: verify the claim against the code before implementing it, clarify the whole
+  set before starting on part of it, and push back with technical reasoning when the reviewer is
+  wrong. That last one matters more here than upstream, because in this suite the reviewer is
+  frequently an *agent* and the recipient is a human who did not write the finding.
+- **`using-git-worktrees` — nothing owns their lifecycle.** `wai-team` parallelises *through*
+  worktrees and four scripts (`open-gap-check`, `doctor`, `open-items`, `verify-arrival`) *sweep*
+  them, but no skill creates or cleans one. The cost is measured, not hypothetical: on 2026-08-20
+  two deleted scratchpad worktrees left stale registrations behind and `open-gap-check` fail-closed
+  at **exit 2** — a red in this repo's own suite, from worktree bookkeeping nobody owns.
+  superpowers has the four rules that were missing: detect existing isolation before creating any,
+  prefer the harness's native worktree tool over raw `git worktree` ("never fight the harness"),
+  verify the directory is ignored, and baseline-test before starting.
+
+**One caution for anyone tempted to install both.** These skills reference each other, and one of
+them **contradicts this suite's merge path**: `finishing-a-development-branch` offers *"merge
+locally — switch to base, pull, merge"* as its first option, which `agent-git-protocol.md` forbids
+outright (only `wai-pr-review` merges, only through the gate). Loading that one installs a
+documented route around the guardrail this repo exists to defend. `receiving-code-review` and
+`using-git-worktrees` are the two that are safely loadable side by side; they touch nothing on the
+merge path.
+
+**And one correction to the table above,** because half an adoption recorded as a whole one is the
+kind of drift this file exists to prevent: what was taken from `requesting-code-review` was the
+*lesser* half. Reading your own diff is now step 5 — but the skill's actual thesis is that a
+reviewer should get **crafted context and no session history**, and `wai-pr-review` still runs in
+the same session as the work it reviews. That was demonstrated on the very PR that added the rule
+(#50): the review declared itself a self-review and could not audit its way out of it. Open, and
+named as open.
 
 ### mattpocock/skills
 <https://github.com/mattpocock/skills> (MIT)


### PR DESCRIPTION
## What & why

You asked for a **place to reference** `obra/superpowers`, not to adopt anything further. The entry
in `REFERENCES.md` already existed from #50 — but it had only two categories, **adopted** and
**rejected on the merits**, and no room for the honest third one: *lanes it covers that this suite
does not cover at all.*

This adds that block. Everything in it is framed as **pointers, not plans** — nothing is scheduled,
and a reader who needs one of these today is better served reading the source than waiting for a
wAI version of it.

| Lane | Why it is a gap here |
|---|---|
| `writing-skills` | This repo tests the two scripts that own the verdict with **184 cases on two shells**, and its **13 prompts with nothing**. Not a suspicion — `docs/learnings/empirical-test-plan.md` opens with *"specification-verified, not behaviour-verified."* superpowers supplies the missing **method** (watch an agent fail without the skill first; micro-test at 5+ reps against a no-guidance control), which is a usable instrument for **Q2** and **Q4** — both open for want of a method rather than of will |
| `receiving-code-review` | The suite is thorough about *producing* findings and about *where a finding lands* (`issues-protocol.md`: fixed / rejected / filed, no fourth outcome). It says nothing about **receiving** one. That matters more here than upstream, because in this suite the reviewer is frequently an *agent* and the recipient is a human who did not write the finding |
| `using-git-worktrees` | `wai-team` parallelises *through* worktrees and four scripts *sweep* them — no skill creates or cleans one. Measured cost, not hypothetical: on 2026-08-20 two deleted scratchpad worktrees left stale registrations and `open-gap-check` fail-closed at **exit 2**, a red in this repo's own suite |

Two further records, both of the kind this file exists to keep:

- **A caution against installing both blindly.** `finishing-a-development-branch` offers *"merge
  locally — switch to base, pull, merge"* as its first option, which `agent-git-protocol.md`
  forbids outright. Loading it installs a documented route around the guardrail this repo defends.
  `receiving-code-review` and `using-git-worktrees` are the two that are safely loadable.
- **A correction to the existing table.** Only the *lesser* half of `requesting-code-review` was
  adopted. Reading your own diff is step 5 — but the skill's thesis is that a reviewer gets
  **crafted context and no session history**, and `wai-pr-review` still runs in the same session as
  the work. Demonstrated on the very PR that added the rule (#50), whose review declared itself a
  self-review. Half an adoption recorded as a whole one is exactly the drift `REFERENCES.md` exists
  to prevent.

**Scope:** two files, docs only. No skill, script, exit code or interface touched.

## Verification

```
$ sh tests/run.sh
184 passed, 0 failed

$ sh tests/numbers-lint.sh
numbers-lint: every measurable claim matches its measurement
              (baseline 87/513, readers 9, runs 8, scripts 29, ledger 47/8).

$ sh tests/lang-guard.sh     → no German outside the three files that document it.
$ sh tests/release-lint.sh   → the tree agrees with its newest tag (v0.3.1).
```

The two numbers this PR *asserts in prose* were measured rather than recalled, because
`numbers-lint` reports `SKIP case count not verified (no --cases given)` and a skipped check is not
a pass:

```
$ ls .claude/skills/*/SKILL.md | wc -l     → 13
$ sh tests/run.sh                          → 184 passed, 0 failed
```

`release-lint` stays green without a CHANGELOG entry being *required* here — its trigger set is
`.claude/skills/**` and this PR touches none of it — but one is included anyway, since a change to
the record is exactly the kind of thing the record should mention.

Not merged, not approved.